### PR TITLE
Add support for OpenMetrics format

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 17.x, 18.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 17.x, 18.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Restore dependencies cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: node_modules

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,9 +32,9 @@ jobs:
         id: cache
         with:
           path: node_modules
-          key: ${{ matrix.os }}-{{ matrix.node-version }}-node_modules-${{ hashFiles('**/package.json') }}
+          key: ${{ matrix.os }}-${{ matrix.node-version }}-node_modules-${{ hashFiles('**/package.json') }}
           restore-keys: |
-            ${{ matrix.os }}-{{ matrix.node-version }}-node_modules-
+            ${{ matrix.os }}-${{ matrix.node-version }}-node_modules-
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: npm i

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- types: converted all the generic Metric types to be optional
+
 - The `done()` functions returned by `gauge.startTimer()` and
   `summary.startTimer()` now return the timed duration. Histograms already had
   this behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
     `processRequests` metrics along with information about any other types of
     async resources that these metrics do not keep a track of (like timers).
 
+- Support gzipped pushgateway requests
+
 ## [14.0.1] - 2021-11-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - changed: typedef for pushgateway to reflect js implementation.
 
+- Improve performance of `gague.inc()` and `gauge.dec()` by calling `hashObject()` once.
+
   Pushgateway's typedef were missing promise return type. That was
   causing vscode to think that push/pushAdd and delete didn't promise
   resulting in incorrect behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+### Added
+
+## [14.1.0] - 2022-08-23
+
+### Changed
+
 - types: converted all the generic Metric types to be optional
 
 - The `done()` functions returned by `gauge.startTimer()` and
@@ -21,14 +27,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Improve performance of `gague.inc()` and `gauge.dec()` by calling `hashObject()` once.
 
-  Pushgateway's typedef were missing promise return type. That was
-  causing vscode to think that push/pushAdd and delete didn't promise
-  resulting in incorrect behavior.
-
 ### Added
 
 - The `processResources` metric was added, which keeps a track of all sorts of
   active resources. It consists of the following gauges:
+
   - `nodejs_active_resources` - Number of active resources that are currently
     keeping the event loop alive, grouped by async resource type.
   - `nodejs_active_resources_total` - Total number of active resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - types: fixed type for `registry.getMetricsAsArray()`
 
-- changed: typedef for pushgateway to reflect js implementation.
-
 - Improve performance of `gague.inc()` and `gauge.dec()` by calling `hashObject()` once.
 
   Pushgateway's typedef were missing promise return type. That was
@@ -37,6 +35,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
     It is supposed to provide the combined result of the `processHandles` and
     `processRequests` metrics along with information about any other types of
     async resources that these metrics do not keep a track of (like timers).
+
+## [14.0.1] - 2021-11-02
+
+### Changed
+
+- changed: typedef for pushgateway to reflect js implementation.
 
 ## [14.0.0] - 2021-09-18
 

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ enabled. They get a single object with the format
 `{labels, value, exemplarLabels}`.
 
 When using exemplars, the registry used for metrics should be set to OpenMetrics
-type (including the global or default registry).
+type (including the global or default registry if no registries are specified).
 
 ### Registy type
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,47 @@ Default labels will be overridden if there is a name conflict.
 
 `register.clear()` will clear default labels.
 
+### Exemplars
+
+The exemplars defined in the OpenMetrics specification can be enabled on Counter
+and Histogram metric types. The default metrics have support for OpenTelemetry,
+they will populate the exemplars with the labels `{traceId, spanId}` and their
+corresponding values.
+
+The format for `inc()` and `observe()` calls are different if exemplars are
+enabled. They get a single object with the format
+`{labels, value, exemplarLabels}`.
+
+When using exemplars, the registry used for metrics should be set to OpenMetrics
+type (including the global or default registry).
+
+### Registy type
+
+The library supports both the old Prometheus format and the OpenMetrics format.
+The format can be set per registry. For default metrics:
+
+```js
+const Prometheus = require('prom-client');
+Prometheus.register.setContentType(
+  Prometheus.Registry.OPENMETRICS_CONTENT_TYPE,
+);
+```
+
+Currently available registry types are defined by the content types:
+
+**PROMETHEUS_CONTENT_TYPE** - version 0.0.4 of the original Prometheus metrics,
+this is currently the default registry type.
+
+**OPENMETRICS_CONTENT_TYPE** - defaults to version 1.0.0 of the
+[OpenMetrics standard](https://github.com/OpenObservability/OpenMetrics/blob/d99b705f611b75fec8f450b05e344e02eea6921d/specification/OpenMetrics.md).
+
+The HTTP Content-Type string for each registry type is exposed both at module
+level (`prometheusContentType` and `openMetricsContentType`) and as static
+properties on the `Registry` object.
+
+The `contentType` constant exposed by the module returns the default content
+type when creating a new registry, currently defaults to Prometheus type.
+
 ### Multiple registries
 
 By default, metrics are automatically registered to the global registry (located
@@ -403,6 +444,9 @@ pass an empty `registers` array and register it manually.
 Registry has a `merge` function that enables you to expose multiple registries
 on the same endpoint. If the same metric name exists in both registries, an
 error will be thrown.
+
+Merging registries of different types is undefined. The user needs to make sure
+all used registries have the same type (Prometheus or OpenMetrics versions).
 
 ```js
 const client = require('prom-client');
@@ -553,9 +597,6 @@ new client.Histogram({
   buckets: client.exponentialBuckets(1, 2, 5), //Create 5 buckets, starting on 1 and with a factor of 2
 });
 ```
-
-The content-type prometheus expects is also exported as a constant, both on the
-`register` and from the main file of this project, called `contentType`.
 
 ### Garbage Collection Metrics
 

--- a/example/exemplars.js
+++ b/example/exemplars.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const { register, Registry, Counter, Histogram } = require('..');
+
+async function makeCounters() {
+	const c = new Counter({
+		name: 'test_counter_exemplar',
+		help: 'Example of a counter with exemplar',
+		labelNames: ['code'],
+		enableExemplars: true,
+	});
+
+	const exemplarLabels = { traceId: '888', spanId: 'jjj' };
+
+	c.inc({
+		labels: { code: 300 },
+		value: 1,
+		exemplarLabels,
+	});
+	c.inc({
+		labels: { code: 200 },
+		exemplarLabels,
+	});
+
+	c.inc({ exemplarLabels });
+	c.inc();
+}
+
+async function makeHistograms() {
+	const h = new Histogram({
+		name: 'test_histogram_exemplar',
+		help: 'Example of a histogram with exemplar',
+		labelNames: ['code'],
+		enableExemplars: true,
+	});
+
+	const exemplarLabels = { traceId: '111', spanId: 'zzz' };
+
+	h.observe({
+		labels: { code: '200' },
+		value: 1,
+		exemplarLabels,
+	});
+
+	h.observe({
+		labels: { code: '200' },
+		value: 3,
+		exemplarLabels,
+	});
+
+	h.observe({
+		labels: { code: '200' },
+		value: 0.3,
+		exemplarLabels,
+	});
+
+	h.observe({
+		labels: { code: '200' },
+		value: 300,
+		exemplarLabels,
+	});
+}
+
+async function main() {
+	// should only use exemplars with OpenMetrics registry types
+	register.setContentType(Registry.OPENMETRICS_CONTENT_TYPE);
+
+	makeCounters();
+	makeHistograms();
+
+	console.log(await register.metrics());
+}
+
+main();

--- a/example/exemplars.js
+++ b/example/exemplars.js
@@ -62,13 +62,28 @@ async function makeHistograms() {
 }
 
 async function main() {
-	// should only use exemplars with OpenMetrics registry types
+	// exemplars will be shown only by OpenMetrics registry types
 	register.setContentType(Registry.OPENMETRICS_CONTENT_TYPE);
 
 	makeCounters();
 	makeHistograms();
 
 	console.log(await register.metrics());
+	console.log('---');
+
+	// if you dont want to set the default registry to OpenMetrics type then you need to create a new registry and assign it to the metric
+
+	register.setContentType(Registry.PROMETHEUS_CONTENT_TYPE);
+	const omReg = new Registry(Registry.OPENMETRICS_CONTENT_TYPE);
+	const c = new Counter({
+		name: 'counter_with_exemplar',
+		help: 'Example of a counter',
+		labelNames: ['code'],
+		registers: [omReg],
+		enableExemplars: true,
+	});
+	c.inc({ labels: { code: '200' }, exemplarLabels: { traceId: 'traceA' } });
+	console.log(await omReg.metrics());
 }
 
 main();

--- a/example/exemplars.ts
+++ b/example/exemplars.ts
@@ -1,0 +1,66 @@
+import * as prom from '../index';
+
+async function prometheusRegistry() {
+	let reg = new prom.Registry();
+
+	let counter = new prom.Counter({
+		name: 'test_counter',
+		help: 'counter help message',
+		registers: [reg],
+		labelNames: ['code'],
+	});
+
+	let hist = new prom.Histogram({
+		name: 'test_histogram',
+		help: 'histogram help message',
+		registers: [reg],
+		labelNames: ['code'],
+	});
+
+	counter.inc({ code: '300' }, 2);
+	hist.observe({ code: '200' }, 1);
+
+	console.log(await reg.metrics());
+}
+
+async function openMetricsRegistry() {
+	let reg = new prom.Registry<prom.OpenMetricsContentType>();
+	reg.setContentType(prom.openMetricsContentType);
+
+	let counter = new prom.Counter({
+		name: 'test_counter',
+		help: 'counter help message',
+		registers: [reg],
+		labelNames: ['code'],
+		enableExemplars: true,
+	});
+
+	let hist = new prom.Histogram({
+		name: 'test_histogram',
+		help: 'histogram help message',
+		registers: [reg],
+		labelNames: ['code'],
+		enableExemplars: true,
+	});
+
+	counter.inc(<prom.IncreaseDataWithExemplar<string>>{
+		value: 2,
+		labels: { code: '300' },
+		exemplarLabels: { traceID: 'traceA' },
+	});
+
+	hist.observe(<prom.ObserveDataWithExemplar<string>>{
+		value: 1,
+		labels: { code: '200' },
+		exemplarLabels: { traceID: 'traceA' },
+	});
+
+	console.log(await reg.metrics());
+}
+
+async function main() {
+	prometheusRegistry();
+	openMetricsRegistry();
+}
+
+main();

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,10 @@
 
 /**
  * Container for all registered metrics
+ * @property {string} PROMETHEUS_CONTENT_TYPE - Content-Type of Prometheus
+ * registry type
+ * @property {string} OPENMETRICS_CONTENT_TYPE - Content-Type of OpenMetrics
+ * registry type.
  */
 export class Registry {
 	/**
@@ -67,6 +71,13 @@ export class Registry {
 	contentType: string;
 
 	/**
+	 * Set the content type of a registry. Used to change between Prometheus and
+	 * OpenMetrics versions.
+	 * @param contentType The type of the registry
+	 */
+	setContentType(contentType: string): void;
+
+	/**
 	 * Merge registers
 	 * @param registers The registers you want to merge together
 	 */
@@ -80,9 +91,20 @@ export type Collector = () => void;
 export const register: Registry;
 
 /**
- * The Content-Type of the metrics for use in the response headers.
+ * HTTP Content-Type for metrics response headers, defaults to Prometheus text
+ * format.
  */
 export const contentType: string;
+
+/**
+ * HTTP Prometheus Content-Type for metrics response headers.
+ */
+export const prometheusContentType: string;
+
+/**
+ * HTTP OpenMetrics Content-Type for metrics response headers.
+ */
+export const openMetricsContentType: string;
 
 export class AggregatorRegistry extends Registry {
 	/**

--- a/index.d.ts
+++ b/index.d.ts
@@ -116,7 +116,7 @@ export class AggregatorRegistry extends Registry {
 /**
  * General metric type
  */
-export type Metric<T extends string> =
+export type Metric<T extends string = string> =
 	| Counter<T>
 	| Gauge<T>
 	| Summary<T>
@@ -163,7 +163,7 @@ export interface CounterConfiguration<T extends string>
 /**
  * A counter is a cumulative metric that represents a single numerical value that only ever goes up
  */
-export class Counter<T extends string> {
+export class Counter<T extends string = string> {
 	/**
 	 * @param configuration Configuration when creating a Counter metric. Name and Help is required.
 	 */
@@ -232,7 +232,7 @@ export interface GaugeConfiguration<T extends string>
 /**
  * A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
  */
-export class Gauge<T extends string> {
+export class Gauge<T extends string = string> {
 	/**
 	 * @param configuration Configuration when creating a Gauge metric. Name and Help is mandatory
 	 */
@@ -368,7 +368,7 @@ export interface HistogramConfiguration<T extends string>
 /**
  * A histogram samples observations (usually things like request durations or response sizes) and counts them in configurable buckets
  */
-export class Histogram<T extends string> {
+export class Histogram<T extends string = string> {
 	/**
 	 * @param configuration Configuration when creating the Histogram. Name and Help is mandatory
 	 */
@@ -470,7 +470,7 @@ export interface SummaryConfiguration<T extends string>
 /**
  * A summary samples observations
  */
-export class Summary<T extends string> {
+export class Summary<T extends string = string> {
 	/**
 	 * @param configuration Configuration when creating Summary metric. Name and Help is mandatory
 	 */
@@ -571,7 +571,7 @@ export class Pushgateway {
 	 */
 	pushAdd(
 		params: Pushgateway.Parameters,
-	): Promise<{ resp?: unknown, body?: unknown }>;
+	): Promise<{ resp?: unknown; body?: unknown }>;
 
 	/**
 	 * Overwrite all metric (using PUT to Pushgateway)
@@ -579,7 +579,7 @@ export class Pushgateway {
 	 */
 	push(
 		params: Pushgateway.Parameters,
-	): Promise<{ resp?: unknown, body?: unknown }>;
+	): Promise<{ resp?: unknown; body?: unknown }>;
 
 	/**
 	 * Delete all metrics for jobName
@@ -587,7 +587,7 @@ export class Pushgateway {
 	 */
 	delete(
 		params: Pushgateway.Parameters,
-	): Promise<{ resp?: unknown, body?: unknown }>;
+	): Promise<{ resp?: unknown; body?: unknown }>;
 }
 
 export namespace Pushgateway {

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ exports.Summary = require('./lib/summary');
 exports.Pushgateway = require('./lib/pushgateway');
 
 exports.linearBuckets = require('./lib/bucketGenerators').linearBuckets;
-exports.exponentialBuckets = require('./lib/bucketGenerators').exponentialBuckets;
+exports.exponentialBuckets =
+	require('./lib/bucketGenerators').exponentialBuckets;
 
 exports.collectDefaultMetrics = require('./lib/defaultMetrics');
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@
 exports.register = require('./lib/registry').globalRegistry;
 exports.Registry = require('./lib/registry');
 exports.contentType = require('./lib/registry').globalRegistry.contentType;
+exports.prometheusContentType = require('./lib/registry').PROMETHEUS_CONTENT_TYPE;
+exports.openMetricsContentType = require('./lib/registry').OPENMETRICS_CONTENT_TYPE;
 exports.validateMetricName = require('./lib/validation').validateMetricName;
 
 exports.Counter = require('./lib/counter');

--- a/index.js
+++ b/index.js
@@ -8,8 +8,10 @@
 exports.register = require('./lib/registry').globalRegistry;
 exports.Registry = require('./lib/registry');
 exports.contentType = require('./lib/registry').globalRegistry.contentType;
-exports.prometheusContentType = require('./lib/registry').PROMETHEUS_CONTENT_TYPE;
-exports.openMetricsContentType = require('./lib/registry').OPENMETRICS_CONTENT_TYPE;
+exports.prometheusContentType =
+	require('./lib/registry').PROMETHEUS_CONTENT_TYPE;
+exports.openMetricsContentType =
+	require('./lib/registry').OPENMETRICS_CONTENT_TYPE;
 exports.validateMetricName = require('./lib/validation').validateMetricName;
 
 exports.Counter = require('./lib/counter');

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -106,9 +106,7 @@ class AggregatorRegistry extends Registry {
 		const aggregatedRegistry = new Registry();
 		const metricsByName = new Grouper();
 
-		if (registryType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			aggregatedRegistry.setContentType(registryType);
-		}
+		aggregatedRegistry.setContentType(registryType);
 
 		// Gather by name
 		metricsArr.forEach(metrics => {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -28,8 +28,8 @@ let listenersAdded = false;
 const requests = new Map(); // Pending requests for workers' local metrics.
 
 class AggregatorRegistry extends Registry {
-	constructor() {
-		super();
+	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE) {
+		super(regContentType);
 		addListeners();
 	}
 
@@ -84,6 +84,10 @@ class AggregatorRegistry extends Registry {
 		});
 	}
 
+	get contentType() {
+		return super.contentType;
+	}
+
 	/**
 	 * Creates a new Registry instance from an array of metrics that were
 	 * created by `registry.getMetricsAsJSON()`. Metrics are aggregated using
@@ -91,11 +95,20 @@ class AggregatorRegistry extends Registry {
 	 * `aggregator` is undefined.
 	 * @param {Array} metricsArr Array of metrics, each of which created by
 	 *   `registry.getMetricsAsJSON()`.
+	 * @param {string} registryType content type of the new registry. Defaults
+	 * to PROMETHEUS_CONTENT_TYPE.
 	 * @return {Registry} aggregated registry.
 	 */
-	static aggregate(metricsArr) {
+	static aggregate(
+		metricsArr,
+		registryType = Registry.PROMETHEUS_CONTENT_TYPE,
+	) {
 		const aggregatedRegistry = new Registry();
 		const metricsByName = new Grouper();
+
+		if (registryType === Registry.OPENMETRICS_CONTENT_TYPE) {
+			aggregatedRegistry.setContentType(registryType);
+		}
 
 		// Gather by name
 		metricsArr.forEach(metrics => {

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -4,20 +4,53 @@
 'use strict';
 
 const util = require('util');
-const type = 'counter';
-const { hashObject, isObject, getLabels, removeLabels } = require('./util');
+const {
+	hashObject,
+	isObject,
+	getLabels,
+	removeLabels,
+	nowTimestamp,
+} = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
+const Exemplar = require('./exemplar');
 
 class Counter extends Metric {
+	constructor(config) {
+		super(config);
+		this.type = 'counter';
+		this.defaultLabels = {};
+		this.defaultValue = 1;
+		this.defaultExemplarLabelSet = {};
+		if (config.enableExemplars) {
+			this.enableExemplars = true;
+			this.inc = this.incWithExemplar;
+		} else {
+			this.inc = this.incWithoutExemplar;
+		}
+	}
+
+	enableExemplars(enable = false) {
+		if (enable) {
+			this.enableExemplars = true;
+		}
+		if (this.enableExemplars) {
+			this.inc = this.incWithExemplar;
+		} else {
+			this.inc = this.incWithoutExemplar;
+		}
+		this.reset();
+	}
+
 	/**
 	 * Increment counter
 	 * @param {object} labels - What label you want to be incremented
 	 * @param {Number} value - Value to increment, if omitted increment with 1
-	 * @returns {void}
+	 * @returns {object} results - object with information about the inc operation
+	 * @returns {string} results.labelHash - hash representation of the labels
 	 */
-	inc(labels, value) {
-		let hash;
+	incWithoutExemplar(labels, value) {
+		let hash = '';
 		if (isObject(labels)) {
 			hash = hashObject(labels);
 			validateLabel(this.labelNames, labels);
@@ -36,6 +69,41 @@ class Counter extends Metric {
 		if (value === null || value === undefined) value = 1;
 
 		setValue(this.hashMap, value, labels, hash);
+
+		return { labelHash: hash };
+	}
+
+	/**
+	 * Increment counter with exemplar, same as inc but accepts labels for an
+	 * exemplar.
+	 * If no label is provided the current exemplar labels are kept unchanged
+	 * (defaults to empty set).
+	 *
+	 * @param {object} incOpts - Object with options about what metric to increase
+	 * @param {object} incOpts.labels - What label you want to be incremented,
+	 *                                  defaults to null (metric with no labels)
+	 * @param {Number} incOpts.value - Value to increment, defaults to 1
+	 * @param {object} incOpts.exemplarLabels - Key-value  labels for the
+	 *                                          exemplar, defaults to empty set {}
+	 * @returns {void}
+	 */
+	incWithExemplar({
+		labels = this.defaultLabels,
+		value = this.defaultValue,
+		exemplarLabels = this.defaultExemplarLabelSet,
+	} = {}) {
+		const res = this.incWithoutExemplar(labels, value);
+		this.updateExemplar(exemplarLabels, value, res.labelHash);
+	}
+
+	updateExemplar(exemplarLabels, value, hash) {
+		if (!isObject(this.hashMap[hash].exemplar)) {
+			this.hashMap[hash].exemplar = new Exemplar();
+		}
+		this.hashMap[hash].exemplar.validateExemplarLabelSet(exemplarLabels);
+		this.hashMap[hash].exemplar.labelSet = exemplarLabels;
+		this.hashMap[hash].exemplar.value = value ? value : 1;
+		this.hashMap[hash].exemplar.timestamp = nowTimestamp();
 	}
 
 	/**
@@ -54,10 +122,11 @@ class Counter extends Metric {
 			const v = this.collect();
 			if (v instanceof Promise) await v;
 		}
+
 		return {
 			help: this.help,
 			name: this.name,
-			type,
+			type: this.type,
 			values: Object.values(this.hashMap),
 			aggregator: this.aggregator,
 		};

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -30,18 +30,6 @@ class Counter extends Metric {
 		}
 	}
 
-	enableExemplars(enable = false) {
-		if (enable) {
-			this.enableExemplars = true;
-		}
-		if (this.enableExemplars) {
-			this.inc = this.incWithExemplar;
-		} else {
-			this.inc = this.incWithoutExemplar;
-		}
-		this.reset();
-	}
-
 	/**
 	 * Increment counter
 	 * @param {object} labels - What label you want to be incremented

--- a/lib/exemplar.js
+++ b/lib/exemplar.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Class representing an OpenMetrics exemplar.
+ *
+ * @property {object} labelSet
+ * @property {number} value
+ * @property {number} [timestamp]
+ * */
+class Exemplar {
+	constructor(labelSet = {}, value = null) {
+		this.labelSet = labelSet;
+		this.value = value;
+	}
+
+	/**
+	 * Validation for the label set format.
+	 * https://github.com/OpenObservability/OpenMetrics/blob/d99b705f611b75fec8f450b05e344e02eea6921d/specification/OpenMetrics.md#exemplars
+	 *
+	 * @param {object} labelSet - Exemplar labels.
+	 * @throws {RangeError}
+	 * @return {void}
+	 */
+	validateExemplarLabelSet(labelSet) {
+		let res = '';
+		for (const [labelName, labelValue] of Object.entries(labelSet)) {
+			res += `${labelName}${labelValue}`;
+		}
+		if (res.length > 128) {
+			throw new RangeError(
+				'Label set size must be smaller than 128 UTF-8 chars',
+			);
+		}
+	}
+}
+
+module.exports = Exemplar;

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const util = require('util');
-const type = 'gauge';
 
 const {
 	setValue,
@@ -18,6 +17,11 @@ const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
 
 class Gauge extends Metric {
+	constructor(config) {
+		super(config);
+		this.type = 'gauge';
+	}
+
 	/**
 	 * Set a gauge to a value
 	 * @param {object} labels - Object with labels and their values
@@ -109,7 +113,7 @@ class Gauge extends Metric {
 		return {
 			help: this.help,
 			name: this.name,
-			type,
+			type: this.type,
 			values: Object.values(this.hashMap),
 			aggregator: this.aggregator,
 		};

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -8,6 +8,7 @@ const type = 'gauge';
 
 const {
 	setValue,
+	setValueDelta,
 	getLabels,
 	hashObject,
 	isObject,
@@ -50,7 +51,7 @@ class Gauge extends Metric {
 		value = getValueArg(labels, value);
 		labels = getLabelArg(labels);
 		if (value === undefined) value = 1;
-		set(this, labels, this._getValue(labels) + value);
+		setDelta(this, labels, value);
 	}
 
 	/**
@@ -63,7 +64,7 @@ class Gauge extends Metric {
 		value = getValueArg(labels, value);
 		labels = getLabelArg(labels);
 		if (value === undefined) value = 1;
-		set(this, labels, this._getValue(labels) - value);
+		setDelta(this, labels, -value);
 	}
 
 	/**
@@ -145,6 +146,16 @@ function set(gauge, labels, value) {
 
 	validateLabel(gauge.labelNames, labels);
 	setValue(gauge.hashMap, value, labels);
+}
+
+function setDelta(gauge, labels, delta) {
+	if (typeof delta !== 'number') {
+		throw new TypeError(`Delta is not a valid number: ${util.format(delta)}`);
+	}
+
+	validateLabel(gauge.labelNames, labels);
+	const hash = hashObject(labels);
+	setValueDelta(gauge.hashMap, delta, labels, hash);
 }
 
 function getLabelArg(labels) {

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -4,16 +4,32 @@
 'use strict';
 
 const util = require('util');
-const type = 'histogram';
-const { getLabels, hashObject, isObject, removeLabels } = require('./util');
+const {
+	getLabels,
+	hashObject,
+	isObject,
+	removeLabels,
+	nowTimestamp,
+} = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
+const Exemplar = require('./exemplar');
 
 class Histogram extends Metric {
 	constructor(config) {
 		super(config, {
 			buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
 		});
+
+		this.type = 'histogram';
+		this.defaultLabels = {};
+		this.defaultExemplarLabelSet = {};
+
+		if (config.enableExemplars) {
+			this.observe = this.observeWithExemplar;
+		} else {
+			this.observe = this.observeWithoutExemplar;
+		}
 
 		for (const label of this.labelNames) {
 			if (label === 'le') {
@@ -27,7 +43,13 @@ class Histogram extends Metric {
 			return acc;
 		}, {});
 
+		this.bucketExemplars = this.upperBounds.reduce((acc, upperBound) => {
+			acc[upperBound] = null;
+			return acc;
+		}, {});
+
 		Object.freeze(this.bucketValues);
+		Object.freeze(this.bucketExemplars);
 		Object.freeze(this.upperBounds);
 
 		if (this.labelNames.length === 0) {
@@ -35,9 +57,22 @@ class Histogram extends Metric {
 				[hashObject({})]: createBaseValues(
 					{},
 					Object.assign({}, this.bucketValues),
+					Object.assign({}, this.bucketExemplars),
 				),
 			};
 		}
+	}
+
+	enableExemplars(enable = false) {
+		if (enable) {
+			this.enableExemplars = true;
+		}
+		if (this.enableExemplars) {
+			this.observe = this.observeWithExemplar;
+		} else {
+			this.observe = this.observeWithoutExemplar;
+		}
+		this.reset();
 	}
 
 	/**
@@ -46,8 +81,31 @@ class Histogram extends Metric {
 	 * @param {Number} value - Value to observe in the histogram
 	 * @returns {void}
 	 */
-	observe(labels, value) {
+	observeWithoutExemplar(labels, value) {
 		observe.call(this, labels === 0 ? 0 : labels || {})(value);
+	}
+
+	observeWithExemplar({
+		labels = this.defaultLabels,
+		value,
+		exemplarLabels = this.defaultExemplarLabelSet,
+	} = {}) {
+		observe.call(this, labels === 0 ? 0 : labels || {})(value);
+		this.updateExemplar(labels, value, exemplarLabels);
+	}
+
+	updateExemplar(labels, value, exemplarLabels) {
+		const hash = hashObject(labels);
+		const b = findBound(this.upperBounds, value);
+		if (!isObject(this.hashMap[hash].bucketExemplars[b])) {
+			this.hashMap[hash].bucketExemplars[b] = new Exemplar();
+		}
+		this.hashMap[hash].bucketExemplars[b].validateExemplarLabelSet(
+			exemplarLabels,
+		);
+		this.hashMap[hash].bucketExemplars[b].labelSet = exemplarLabels;
+		this.hashMap[hash].bucketExemplars[b].value = value;
+		this.hashMap[hash].bucketExemplars[b].timestamp = nowTimestamp();
 	}
 
 	async get() {
@@ -63,7 +121,7 @@ class Histogram extends Metric {
 		return {
 			name: this.name,
 			help: this.help,
-			type,
+			type: this.type,
 			values,
 			aggregator: this.aggregator,
 		};
@@ -83,6 +141,7 @@ class Histogram extends Metric {
 		this.hashMap[hash] = createBaseValues(
 			labels,
 			Object.assign({}, this.bucketValues),
+			Object.assign({}, this.bucketExemplars),
 		);
 	}
 
@@ -129,11 +188,12 @@ function startTimer(startLabels) {
 	};
 }
 
-function setValuePair(labels, value, metricName) {
+function setValuePair(labels, value, metricName, exemplar) {
 	return {
 		labels,
 		value,
 		metricName,
+		exemplar,
 	};
 }
 
@@ -164,6 +224,7 @@ function observe(labels) {
 			valueFromMap = createBaseValues(
 				labelValuePair.labels,
 				Object.assign({}, this.bucketValues),
+				Object.assign({}, this.bucketExemplars),
 			);
 		}
 
@@ -180,10 +241,11 @@ function observe(labels) {
 	};
 }
 
-function createBaseValues(labels, bucketValues) {
+function createBaseValues(labels, bucketValues, bucketExemplars) {
 	return {
 		labels,
 		bucketValues,
+		bucketExemplars,
 		sum: 0,
 		count: 0,
 	};
@@ -213,7 +275,14 @@ function extractBucketValuesForExport(histogram) {
 			for (const labelName of bucketLabelNames) {
 				lbls[labelName] = bucketData.labels[labelName];
 			}
-			buckets.push(setValuePair(lbls, acc, `${histogram.name}_bucket`));
+			buckets.push(
+				setValuePair(
+					lbls,
+					acc,
+					`${histogram.name}_bucket`,
+					bucketData.bucketExemplars[upperBound],
+				),
+			);
 		}
 		return { buckets, data: bucketData };
 	};
@@ -228,7 +297,12 @@ function addSumAndCountForExport(histogram) {
 			infLabel[label] = d.data.labels[label];
 		}
 		acc.push(
-			setValuePair(infLabel, d.data.count, `${histogram.name}_bucket`),
+			setValuePair(
+				infLabel,
+				d.data.count,
+				`${histogram.name}_bucket`,
+				d.data.bucketExemplars['-1'],
+			),
 			setValuePair(d.data.labels, d.data.sum, `${histogram.name}_sum`),
 			setValuePair(d.data.labels, d.data.count, `${histogram.name}_count`),
 		);

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -63,18 +63,6 @@ class Histogram extends Metric {
 		}
 	}
 
-	enableExemplars(enable = false) {
-		if (enable) {
-			this.enableExemplars = true;
-		}
-		if (this.enableExemplars) {
-			this.observe = this.observeWithExemplar;
-		} else {
-			this.observe = this.observeWithoutExemplar;
-		}
-		this.reset();
-	}
-
 	/**
 	 * Observe a value in histogram
 	 * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { globalRegistry } = require('./registry');
+const Registry = require('./registry');
 const { isObject } = require('./util');
 const { validateMetricName, validateLabelName } = require('./validation');
 
@@ -16,7 +16,7 @@ class Metric {
 			this,
 			{
 				labelNames: [],
-				registers: [globalRegistry],
+				registers: [Registry.globalRegistry],
 				aggregator: 'sum',
 				enableExemplars: false,
 			},
@@ -25,7 +25,7 @@ class Metric {
 		);
 		if (!this.registers) {
 			// in case config.registers is `undefined`
-			this.registers = [globalRegistry];
+			this.registers = [Registry.globalRegistry];
 		}
 		if (!this.help) {
 			throw new Error('Missing mandatory help parameter');
@@ -46,6 +46,14 @@ class Metric {
 		this.reset();
 
 		for (const register of this.registers) {
+			if (
+				this.enableExemplars &&
+				register.contentType === Registry.PROMETHEUS_CONTENT_TYPE
+			) {
+				throw new TypeError(
+					'Exemplars are supported only on OpenMetrics registries',
+				);
+			}
 			register.registerMetric(this);
 		}
 	}

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -18,6 +18,7 @@ class Metric {
 				labelNames: [],
 				registers: [globalRegistry],
 				aggregator: 'sum',
+				enableExemplars: false,
 			},
 			defaults,
 			config,

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -34,6 +34,7 @@ module.exports = (registry, config = {}) => {
 		name: namePrefix + NODEJS_GC_DURATION_SECONDS,
 		help: 'Garbage collection duration by kind, one of major, minor, incremental or weakcb.',
 		labelNames: ['kind', ...labelNames],
+		enableExemplars: false,
 		buckets,
 		registers: registry ? [registry] : undefined,
 	});
@@ -44,7 +45,6 @@ module.exports = (registry, config = {}) => {
 		// Node >= 16 uses entry.detail.kind
 		// See: https://nodejs.org/docs/latest-v16.x/api/deprecations.html#deprecations_dep0152_extension_performanceentry_properties
 		const kind = entry.detail ? kinds[entry.detail.kind] : kinds[entry.kind];
-
 		// Convert duration from milliseconds to seconds
 		gcHistogram.observe(Object.assign({ kind }, labels), entry.duration / 1000);
 	});

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -32,8 +32,7 @@ module.exports = (registry, config = {}) => {
 		: DEFAULT_GC_DURATION_BUCKETS;
 	const gcHistogram = new Histogram({
 		name: namePrefix + NODEJS_GC_DURATION_SECONDS,
-		help:
-			'Garbage collection duration by kind, one of major, minor, incremental or weakcb.',
+		help: 'Garbage collection duration by kind, one of major, minor, incremental or weakcb.',
 		labelNames: ['kind', ...labelNames],
 		buckets,
 		registers: registry ? [registry] : undefined,

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const OtelApi = require('@opentelemetry/api');
 const Counter = require('../counter');
+
 const PROCESS_CPU_USER_SECONDS = 'process_cpu_user_seconds_total';
 const PROCESS_CPU_SYSTEM_SECONDS = 'process_cpu_system_seconds_total';
 const PROCESS_CPU_SECONDS = 'process_cpu_seconds_total';
@@ -9,6 +11,7 @@ module.exports = (registry, config = {}) => {
 	const registers = registry ? [registry] : undefined;
 	const namePrefix = config.prefix ? config.prefix : '';
 	const labels = config.labels ? config.labels : {};
+	const exemplars = config.enableExemplars ? config.enableExemplars : false;
 	const labelNames = Object.keys(labels);
 
 	let lastCpuUsage = process.cpuUsage();
@@ -16,6 +19,7 @@ module.exports = (registry, config = {}) => {
 	const cpuUserUsageCounter = new Counter({
 		name: namePrefix + PROCESS_CPU_USER_SECONDS,
 		help: 'Total user CPU time spent in seconds.',
+		enableExemplars: exemplars,
 		registers,
 		labelNames,
 		// Use this one metric's `collect` to set all metrics' values.
@@ -27,20 +31,51 @@ module.exports = (registry, config = {}) => {
 
 			lastCpuUsage = cpuUsage;
 
-			cpuUserUsageCounter.inc(labels, userUsageMicros / 1e6);
-			cpuSystemUsageCounter.inc(labels, systemUsageMicros / 1e6);
-			cpuUsageCounter.inc(labels, (userUsageMicros + systemUsageMicros) / 1e6);
+			if (this.enableExemplars) {
+				let exemplarLabels = {};
+				const currentSpan = OtelApi.trace.getSpan(OtelApi.context.active());
+				if (currentSpan) {
+					exemplarLabels = {
+						traceId: currentSpan.spanContext().traceId,
+						spanId: currentSpan.spanContext().spanId,
+					};
+				}
+				cpuUserUsageCounter.inc({
+					labels,
+					value: userUsageMicros / 1e6,
+					exemplarLabels,
+				});
+				cpuSystemUsageCounter.inc({
+					labels,
+					value: systemUsageMicros / 1e6,
+					exemplarLabels,
+				});
+				cpuUsageCounter.inc({
+					labels,
+					value: (userUsageMicros + systemUsageMicros) / 1e6,
+					exemplarLabels,
+				});
+			} else {
+				cpuUserUsageCounter.inc(labels, userUsageMicros / 1e6);
+				cpuSystemUsageCounter.inc(labels, systemUsageMicros / 1e6);
+				cpuUsageCounter.inc(
+					labels,
+					(userUsageMicros + systemUsageMicros) / 1e6,
+				);
+			}
 		},
 	});
 	const cpuSystemUsageCounter = new Counter({
 		name: namePrefix + PROCESS_CPU_SYSTEM_SECONDS,
 		help: 'Total system CPU time spent in seconds.',
+		enableExemplars: exemplars,
 		registers,
 		labelNames,
 	});
 	const cpuUsageCounter = new Counter({
 		name: namePrefix + PROCESS_CPU_SECONDS,
 		help: 'Total user and system CPU time spent in seconds.',
+		enableExemplars: exemplars,
 		registers,
 		labelNames,
 	});

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -20,8 +20,7 @@ module.exports = (registry, config = {}) => {
 
 	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_HANDLES,
-		help:
-			'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.',
+		help: 'Number of active libuv handles grouped by handle type. Every handle type is C++ class name.',
 		labelNames: ['type', ...labelNames],
 		registers,
 		collect() {

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -18,8 +18,7 @@ module.exports = (registry, config = {}) => {
 
 	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_REQUESTS,
-		help:
-			'Number of active libuv requests grouped by request type. Every request type is C++ class name.',
+		help: 'Number of active libuv requests grouped by request type. Every request type is C++ class name.',
 		labelNames: ['type', ...labelNames],
 		registers: registry ? [registry] : undefined,
 		collect() {

--- a/lib/metrics/processResources.js
+++ b/lib/metrics/processResources.js
@@ -17,8 +17,7 @@ module.exports = (registry, config = {}) => {
 
 	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_RESOURCES,
-		help:
-			'Number of active resources that are currently keeping the event loop alive, grouped by async resource type.',
+		help: 'Number of active resources that are currently keeping the event loop alive, grouped by async resource type.',
 		labelNames: ['type', ...labelNames],
 		registers: registry ? [registry] : undefined,
 		collect() {

--- a/lib/pushgateway.js
+++ b/lib/pushgateway.js
@@ -3,6 +3,7 @@
 const url = require('url');
 const http = require('http');
 const https = require('https');
+const { gzipSync } = require('zlib');
 const { globalRegistry } = require('./registry');
 
 class Pushgateway {
@@ -79,6 +80,12 @@ async function useGateway(method, job, groupings) {
 			this.registry
 				.metrics()
 				.then(metrics => {
+					if (
+						options.headers &&
+						options.headers['Content-Encoding'] === 'gzip'
+					) {
+						metrics = gzipSync(metrics);
+					}
 					req.write(metrics);
 					req.end();
 				})

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -10,27 +10,38 @@ function escapeLabelValue(str) {
 	}
 	return escapeString(str).replace(/"/g, '\\"');
 }
+function standardizeCounterName(name) {
+	if (name.endsWith('_total')) {
+		return name.replace('_total', '');
+	}
+	return name;
+}
 
 class Registry {
-	constructor() {
+	static get PROMETHEUS_CONTENT_TYPE() {
+		return 'text/plain; version=0.0.4; charset=utf-8';
+	}
+
+	static get OPENMETRICS_CONTENT_TYPE() {
+		return 'application/openmetrics-text; version=1.0.0; charset=utf-8';
+	}
+
+	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE) {
 		this._metrics = {};
 		this._collectors = [];
 		this._defaultLabels = {};
+		this._contentType = regContentType;
 	}
 
 	getMetricsAsArray() {
 		return Object.values(this._metrics);
 	}
 
-	async getMetricAsPrometheusString(metric) {
-		const item = await metric.get();
-		const name = escapeString(item.name);
-		const help = `# HELP ${name} ${escapeString(item.help)}`;
-		const type = `# TYPE ${name} ${item.type}`;
+	getLabelSetAsString(metric) {
 		const defaultLabelNames = Object.keys(this._defaultLabels);
-
 		let values = '';
-		for (const val of item.values || []) {
+
+		for (const val of metric.values || []) {
 			val.labels = val.labels || {};
 
 			if (defaultLabelNames.length > 0) {
@@ -43,7 +54,13 @@ class Registry {
 				}
 			}
 
-			let metricName = val.metricName || item.name;
+			let metricName = val.metricName || metric.name;
+			if (
+				this.contentType === Registry.OPENMETRICS_CONTENT_TYPE &&
+				metric.type === 'counter'
+			) {
+				metricName = `${metricName}_total`;
+			}
 
 			const keys = Object.keys(val.labels);
 			const size = keys.length;
@@ -56,9 +73,43 @@ class Registry {
 				labels += `${keys[i]}="${escapeLabelValue(val.labels[keys[i]])}"`;
 				metricName += `{${labels}}`;
 			}
-
-			values += `${metricName} ${getValueAsString(val.value)}\n`;
+			values += `${metricName} ${getValueAsString(val.value)}`;
+			if (val.exemplar) {
+				const exemplarKeys = Object.keys(val.exemplar.labelSet);
+				const exemplarSize = exemplarKeys.length;
+				if (exemplarSize > 0) {
+					let labels = '';
+					let i = 0;
+					for (; i < exemplarSize - 1; i++) {
+						labels += `${exemplarKeys[i]}="${escapeLabelValue(
+							val.exemplar.labelSet[exemplarKeys[i]],
+						)}",`;
+					}
+					labels += `${exemplarKeys[i]}="${escapeLabelValue(
+						val.exemplar.labelSet[exemplarKeys[i]],
+					)}"`;
+					values += ` # {${labels}} ${getValueAsString(val.exemplar.value)} ${
+						val.exemplar.timestamp
+					}`;
+				} else {
+					values += ` # {} ${getValueAsString(val.exemplar.value)} ${
+						val.exemplar.timestamp
+					}`;
+				}
+			}
+			values += '\n';
 		}
+
+		return values;
+	}
+
+	async getMetricsAsString(metrics) {
+		const metric = await metrics.get();
+
+		const name = escapeString(metric.name);
+		const help = `# HELP ${name} ${escapeString(metric.help)}`;
+		const type = `# TYPE ${name} ${metric.type}`;
+		const values = this.getLabelSetAsString(metric);
 
 		return `${help}\n${type}\n${values}`.trim();
 	}
@@ -67,12 +118,22 @@ class Registry {
 		const promises = [];
 
 		for (const metric of this.getMetricsAsArray()) {
-			promises.push(this.getMetricAsPrometheusString(metric));
+			if (
+				this.contentType === Registry.OPENMETRICS_CONTENT_TYPE &&
+				metric.type === 'counter'
+			) {
+				metric.name = standardizeCounterName(metric.name);
+			}
+			promises.push(this.getMetricsAsString(metric));
 		}
 
 		const resolves = await Promise.all(promises);
 
-		return `${resolves.join('\n\n')}\n`;
+		if (this.contentType === Registry.OPENMETRICS_CONTENT_TYPE) {
+			return `${resolves.join('\n')}\n# EOF\n`;
+		} else {
+			return `${resolves.join('\n\n')}\n`;
+		}
 	}
 
 	registerMetric(metric) {
@@ -126,7 +187,7 @@ class Registry {
 	}
 
 	getSingleMetricAsString(name) {
-		return this.getMetricAsPrometheusString(this._metrics[name]);
+		return this.getMetricsAsString(this._metrics[name]);
 	}
 
 	getSingleMetric(name) {
@@ -144,11 +205,28 @@ class Registry {
 	}
 
 	get contentType() {
-		return 'text/plain; version=0.0.4; charset=utf-8';
+		return this._contentType;
 	}
 
+	setContentType(metricsContentType) {
+		if (metricsContentType === Registry.OPENMETRICS_CONTENT_TYPE) {
+			this._contentType = Registry.OPENMETRICS_CONTENT_TYPE;
+		} else {
+			this._contentType = Registry.PROMETHEUS_CONTENT_TYPE;
+		}
+	}
+
+	/* Merge behaviour between registries of different types is undefined. The
+	 * user should only provide an array or registries of the same type. */
 	static merge(registers) {
-		const mergedRegistry = new Registry();
+		let regType = Registry.PROMETHEUS_CONTENT_TYPE;
+		for (const reg of registers) {
+			if (reg.type && reg.type !== regType) {
+				regType = reg.type;
+				break;
+			}
+		}
+		const mergedRegistry = new Registry(regType);
 
 		const metricsToMerge = registers.reduce(
 			(acc, reg) => acc.concat(reg.getMetricsAsArray()),

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const { getValueAsString } = require('./util');
 
 function escapeString(str) {
@@ -30,6 +31,12 @@ class Registry {
 		this._metrics = {};
 		this._collectors = [];
 		this._defaultLabels = {};
+		if (
+			regContentType !== Registry.PROMETHEUS_CONTENT_TYPE &&
+			regContentType !== Registry.OPENMETRICS_CONTENT_TYPE
+		) {
+			throw new TypeError('Content type unsupported');
+		}
 		this._contentType = regContentType;
 	}
 
@@ -74,7 +81,10 @@ class Registry {
 				metricName += `{${labels}}`;
 			}
 			values += `${metricName} ${getValueAsString(val.value)}`;
-			if (val.exemplar) {
+			if (
+				val.exemplar &&
+				this.contentType === Registry.OPENMETRICS_CONTENT_TYPE
+			) {
 				const exemplarKeys = Object.keys(val.exemplar.labelSet);
 				const exemplarSize = exemplarKeys.length;
 				if (exemplarSize > 0) {
@@ -209,21 +219,23 @@ class Registry {
 	}
 
 	setContentType(metricsContentType) {
-		if (metricsContentType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			this._contentType = Registry.OPENMETRICS_CONTENT_TYPE;
+		if (
+			metricsContentType === Registry.OPENMETRICS_CONTENT_TYPE ||
+			metricsContentType === Registry.PROMETHEUS_CONTENT_TYPE
+		) {
+			this._contentType = metricsContentType;
 		} else {
-			this._contentType = Registry.PROMETHEUS_CONTENT_TYPE;
+			throw new Error('Content type unsupported');
 		}
 	}
 
-	/* Merge behaviour between registries of different types is undefined. The
-	 * user should only provide an array or registries of the same type. */
 	static merge(registers) {
-		let regType = Registry.PROMETHEUS_CONTENT_TYPE;
+		const regType = registers[0].contentType;
 		for (const reg of registers) {
-			if (reg.type && reg.type !== regType) {
-				regType = reg.type;
-				break;
+			if (reg.contentType !== regType) {
+				throw new Error(
+					'Registers can only be merged if they have the same content type',
+				);
 			}
 		}
 		const mergedRegistry = new Registry(regType);

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const util = require('util');
-const type = 'summary';
 const { getLabels, hashObject, removeLabels } = require('./util');
 const { validateLabel } = require('./validation');
 const { Metric } = require('./metric');
@@ -19,6 +18,8 @@ class Summary extends Metric {
 			compressCount: DEFAULT_COMPRESS_COUNT,
 			hashMap: {},
 		});
+
+		this.type = 'summary';
 
 		for (const label of this.labelNames) {
 			if (label === 'quantile')
@@ -65,7 +66,7 @@ class Summary extends Metric {
 		return {
 			name: this.name,
 			help: this.help,
-			type,
+			type: this.type,
 			values,
 			aggregator: this.aggregator,
 		};

--- a/lib/util.js
+++ b/lib/util.js
@@ -87,6 +87,10 @@ exports.isObject = function isObject(obj) {
 	return obj === Object(obj);
 };
 
+exports.nowTimestamp = function nowTimestamp() {
+	return Date.now() / 1000;
+};
+
 class Grouper extends Map {
 	/**
 	 * Adds the `value` to the `key`'s array of values.

--- a/lib/util.js
+++ b/lib/util.js
@@ -28,6 +28,21 @@ exports.setValue = function setValue(hashMap, value, labels) {
 	return hashMap;
 };
 
+exports.setValueDelta = function setValueDelta(
+	hashMap,
+	deltaValue,
+	labels,
+	hash = '',
+) {
+	const value = typeof deltaValue === 'number' ? deltaValue : 0;
+	if (hashMap[hash]) {
+		hashMap[hash].value += value;
+	} else {
+		hashMap[hash] = { value, labels };
+	}
+	return hashMap;
+};
+
 exports.getLabels = function (labelNames, args) {
 	if (typeof args[0] === 'object') {
 		return args[0];

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"typescript": "^4.0.2"
 	},
 	"dependencies": {
+		"@opentelemetry/api": "^1.0.2",
 		"tdigest": "^0.1.1"
 	},
 	"types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prom-client",
-	"version": "14.0.1",
+	"version": "14.1.0",
 	"description": "Client for prometheus",
 	"main": "index.js",
 	"files": [

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
 	},
 	"scripts": {
 		"benchmarks": "node ./benchmarks/index.js",
-		"test": "npm run lint && npm run compile-typescript && npm run test-unit",
+		"test": "npm run lint && npm run check-prettier && npm run compile-typescript && npm run test-unit",
 		"lint": "eslint .",
 		"test-unit": "jest",
+		"run-prettier": "prettier . .eslintrc",
+		"check-prettier": "npm run run-prettier -- --check",
 		"compile-typescript": "tsc --project ."
 	},
 	"repository": {
@@ -41,7 +43,7 @@
 		"jest": "^26.0.1",
 		"lint-staged": "^10.0.4",
 		"nock": "^13.0.5",
-		"prettier": "2.0.5",
+		"prettier": "2.7.1",
 		"typescript": "^4.0.2"
 	},
 	"dependencies": {
@@ -62,6 +64,7 @@
 		"useTabs": true,
 		"arrowParens": "avoid",
 		"trailingComma": "all",
+		"endOfLine": "auto",
 		"overrides": [
 			{
 				"files": "*.md",

--- a/test/__snapshots__/counterTest.js.snap
+++ b/test/__snapshots__/counterTest.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`counter with $tag registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`counter with OpenMetrics registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`counter with $tag registry remove should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+exports[`counter with OpenMetrics registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`counter with $tag registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`counter with OpenMetrics registry with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
 
-exports[`counter with $tag registry with params as object labels should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+exports[`counter with OpenMetrics registry with params as object should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
 
-exports[`counter with $tag registry with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
+exports[`counter with Prometheus registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`counter with $tag registry with params as object should not be possible to decrease a counter 2`] = `"It is not possible to decrease a counter"`;
+exports[`counter with Prometheus registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`counter with $tag registry with params as object should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
+exports[`counter with Prometheus registry with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
 
-exports[`counter with $tag registry with params as object should throw an error when the value is not a number 2`] = `"Value is not a valid number: 3ms"`;
+exports[`counter with Prometheus registry with params as object should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;

--- a/test/__snapshots__/counterTest.js.snap
+++ b/test/__snapshots__/counterTest.js.snap
@@ -1,9 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`counter remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`counter with $tag registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`counter with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`counter with $tag registry remove should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
 
-exports[`counter with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
+exports[`counter with $tag registry with params as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`counter with params as object should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
+exports[`counter with $tag registry with params as object labels should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+
+exports[`counter with $tag registry with params as object should not be possible to decrease a counter 1`] = `"It is not possible to decrease a counter"`;
+
+exports[`counter with $tag registry with params as object should not be possible to decrease a counter 2`] = `"It is not possible to decrease a counter"`;
+
+exports[`counter with $tag registry with params as object should throw an error when the value is not a number 1`] = `"Value is not a valid number: 3ms"`;
+
+exports[`counter with $tag registry with params as object should throw an error when the value is not a number 2`] = `"Value is not a valid number: 3ms"`;

--- a/test/__snapshots__/gaugeTest.js.snap
+++ b/test/__snapshots__/gaugeTest.js.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gauge with $tag registry global registry with parameters as object should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+exports[`gauge with OpenMetrics registry global registry with parameters as object should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
 
-exports[`gauge with $tag registry global registry with parameters as object should not allow non numbers 2`] = `"Value is not a valid number: asd"`;
+exports[`gauge with Prometheus registry global registry with parameters as object should not allow non numbers 1`] = `"Value is not a valid number: asd"`;

--- a/test/__snapshots__/gaugeTest.js.snap
+++ b/test/__snapshots__/gaugeTest.js.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gauge global registry with parameters as object should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+exports[`gauge with $tag registry global registry with parameters as object should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+
+exports[`gauge with $tag registry global registry with parameters as object should not allow non numbers 2`] = `"Value is not a valid number: asd"`;

--- a/test/__snapshots__/histogramTest.js.snap
+++ b/test/__snapshots__/histogramTest.js.snap
@@ -1,9 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`histogram with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
+exports[`histogram with $tag registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
 
-exports[`histogram with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`histogram with $tag registry with object as params with global registry labels should not allow different number of labels 2`] = `"Invalid number of arguments"`;
 
-exports[`histogram with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
+exports[`histogram with $tag registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`histogram with object as params with global registry should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+exports[`histogram with $tag registry with object as params with global registry remove should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+
+exports[`histogram with $tag registry with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
+
+exports[`histogram with $tag registry with object as params with global registry should not allow le as a custom label 2`] = `"le is a reserved label keyword"`;
+
+exports[`histogram with $tag registry with object as params with global registry should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+
+exports[`histogram with $tag registry with object as params with global registry should not allow non numbers 2`] = `"Value is not a valid number: asd"`;

--- a/test/__snapshots__/histogramTest.js.snap
+++ b/test/__snapshots__/histogramTest.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`histogram with $tag registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
+exports[`histogram with OpenMetrics registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
 
-exports[`histogram with $tag registry with object as params with global registry labels should not allow different number of labels 2`] = `"Invalid number of arguments"`;
+exports[`histogram with OpenMetrics registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`histogram with $tag registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`histogram with OpenMetrics registry with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
 
-exports[`histogram with $tag registry with object as params with global registry remove should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+exports[`histogram with OpenMetrics registry with object as params with global registry should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
 
-exports[`histogram with $tag registry with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
+exports[`histogram with Prometheus registry with object as params with global registry labels should not allow different number of labels 1`] = `"Invalid number of arguments"`;
 
-exports[`histogram with $tag registry with object as params with global registry should not allow le as a custom label 2`] = `"le is a reserved label keyword"`;
+exports[`histogram with Prometheus registry with object as params with global registry remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`histogram with $tag registry with object as params with global registry should not allow non numbers 1`] = `"Value is not a valid number: asd"`;
+exports[`histogram with Prometheus registry with object as params with global registry should not allow le as a custom label 1`] = `"le is a reserved label keyword"`;
 
-exports[`histogram with $tag registry with object as params with global registry should not allow non numbers 2`] = `"Value is not a valid number: asd"`;
+exports[`histogram with Prometheus registry with object as params with global registry should not allow non numbers 1`] = `"Value is not a valid number: asd"`;

--- a/test/__snapshots__/registerTest.js.snap
+++ b/test/__snapshots__/registerTest.js.snap
@@ -1,21 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`$tag register should not output all initialized metrics at value 0 if labels 1`] = `
-"# HELP counter help
-# TYPE counter counter
-
-# HELP gauge help
-# TYPE gauge gauge
-
-# HELP histogram help
-# TYPE histogram histogram
-
-# HELP summary help
-# TYPE summary summary
-"
-`;
-
-exports[`$tag register should not output all initialized metrics at value 0 if labels 2`] = `
+exports[`Register with OpenMetrics type should not output all initialized metrics at value 0 if labels 1`] = `
 "# HELP counter help
 # TYPE counter counter
 # HELP gauge help
@@ -28,7 +13,60 @@ exports[`$tag register should not output all initialized metrics at value 0 if l
 "
 `;
 
-exports[`$tag register should output all initialized metrics at value 0 1`] = `
+exports[`Register with OpenMetrics type should output all initialized metrics at value 0 1`] = `
+"# HELP counter help
+# TYPE counter counter
+counter_total 0
+# HELP gauge help
+# TYPE gauge gauge
+gauge 0
+# HELP histogram help
+# TYPE histogram histogram
+histogram_bucket{le=\\"0.005\\"} 0
+histogram_bucket{le=\\"0.01\\"} 0
+histogram_bucket{le=\\"0.025\\"} 0
+histogram_bucket{le=\\"0.05\\"} 0
+histogram_bucket{le=\\"0.1\\"} 0
+histogram_bucket{le=\\"0.25\\"} 0
+histogram_bucket{le=\\"0.5\\"} 0
+histogram_bucket{le=\\"1\\"} 0
+histogram_bucket{le=\\"2.5\\"} 0
+histogram_bucket{le=\\"5\\"} 0
+histogram_bucket{le=\\"10\\"} 0
+histogram_bucket{le=\\"+Inf\\"} 0
+histogram_sum 0
+histogram_count 0
+# HELP summary help
+# TYPE summary summary
+summary{quantile=\\"0.01\\"} 0
+summary{quantile=\\"0.05\\"} 0
+summary{quantile=\\"0.5\\"} 0
+summary{quantile=\\"0.9\\"} 0
+summary{quantile=\\"0.95\\"} 0
+summary{quantile=\\"0.99\\"} 0
+summary{quantile=\\"0.999\\"} 0
+summary_sum 0
+summary_count 0
+# EOF
+"
+`;
+
+exports[`Register with Prometheus type should not output all initialized metrics at value 0 if labels 1`] = `
+"# HELP counter help
+# TYPE counter counter
+
+# HELP gauge help
+# TYPE gauge gauge
+
+# HELP histogram help
+# TYPE histogram histogram
+
+# HELP summary help
+# TYPE summary summary
+"
+`;
+
+exports[`Register with Prometheus type should output all initialized metrics at value 0 1`] = `
 "# HELP counter help
 # TYPE counter counter
 counter 0
@@ -65,43 +103,5 @@ summary{quantile=\\"0.99\\"} 0
 summary{quantile=\\"0.999\\"} 0
 summary_sum 0
 summary_count 0
-"
-`;
-
-exports[`$tag register should output all initialized metrics at value 0 2`] = `
-"# HELP counter help
-# TYPE counter counter
-counter_total 0
-# HELP gauge help
-# TYPE gauge gauge
-gauge 0
-# HELP histogram help
-# TYPE histogram histogram
-histogram_bucket{le=\\"0.005\\"} 0
-histogram_bucket{le=\\"0.01\\"} 0
-histogram_bucket{le=\\"0.025\\"} 0
-histogram_bucket{le=\\"0.05\\"} 0
-histogram_bucket{le=\\"0.1\\"} 0
-histogram_bucket{le=\\"0.25\\"} 0
-histogram_bucket{le=\\"0.5\\"} 0
-histogram_bucket{le=\\"1\\"} 0
-histogram_bucket{le=\\"2.5\\"} 0
-histogram_bucket{le=\\"5\\"} 0
-histogram_bucket{le=\\"10\\"} 0
-histogram_bucket{le=\\"+Inf\\"} 0
-histogram_sum 0
-histogram_count 0
-# HELP summary help
-# TYPE summary summary
-summary{quantile=\\"0.01\\"} 0
-summary{quantile=\\"0.05\\"} 0
-summary{quantile=\\"0.5\\"} 0
-summary{quantile=\\"0.9\\"} 0
-summary{quantile=\\"0.95\\"} 0
-summary{quantile=\\"0.99\\"} 0
-summary{quantile=\\"0.999\\"} 0
-summary_sum 0
-summary_count 0
-# EOF
 "
 `;

--- a/test/__snapshots__/registerTest.js.snap
+++ b/test/__snapshots__/registerTest.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`register should not output all initialized metrics at value 0 if labels 1`] = `
+exports[`$tag register should not output all initialized metrics at value 0 if labels 1`] = `
 "# HELP counter help
 # TYPE counter counter
 
@@ -15,7 +15,20 @@ exports[`register should not output all initialized metrics at value 0 if labels
 "
 `;
 
-exports[`register should output all initialized metrics at value 0 1`] = `
+exports[`$tag register should not output all initialized metrics at value 0 if labels 2`] = `
+"# HELP counter help
+# TYPE counter counter
+# HELP gauge help
+# TYPE gauge gauge
+# HELP histogram help
+# TYPE histogram histogram
+# HELP summary help
+# TYPE summary summary
+# EOF
+"
+`;
+
+exports[`$tag register should output all initialized metrics at value 0 1`] = `
 "# HELP counter help
 # TYPE counter counter
 counter 0
@@ -52,5 +65,43 @@ summary{quantile=\\"0.99\\"} 0
 summary{quantile=\\"0.999\\"} 0
 summary_sum 0
 summary_count 0
+"
+`;
+
+exports[`$tag register should output all initialized metrics at value 0 2`] = `
+"# HELP counter help
+# TYPE counter counter
+counter_total 0
+# HELP gauge help
+# TYPE gauge gauge
+gauge 0
+# HELP histogram help
+# TYPE histogram histogram
+histogram_bucket{le=\\"0.005\\"} 0
+histogram_bucket{le=\\"0.01\\"} 0
+histogram_bucket{le=\\"0.025\\"} 0
+histogram_bucket{le=\\"0.05\\"} 0
+histogram_bucket{le=\\"0.1\\"} 0
+histogram_bucket{le=\\"0.25\\"} 0
+histogram_bucket{le=\\"0.5\\"} 0
+histogram_bucket{le=\\"1\\"} 0
+histogram_bucket{le=\\"2.5\\"} 0
+histogram_bucket{le=\\"5\\"} 0
+histogram_bucket{le=\\"10\\"} 0
+histogram_bucket{le=\\"+Inf\\"} 0
+histogram_sum 0
+histogram_count 0
+# HELP summary help
+# TYPE summary summary
+summary{quantile=\\"0.01\\"} 0
+summary{quantile=\\"0.05\\"} 0
+summary{quantile=\\"0.5\\"} 0
+summary{quantile=\\"0.9\\"} 0
+summary{quantile=\\"0.95\\"} 0
+summary{quantile=\\"0.99\\"} 0
+summary{quantile=\\"0.999\\"} 0
+summary_sum 0
+summary_count 0
+# EOF
 "
 `;

--- a/test/__snapshots__/summaryTest.js.snap
+++ b/test/__snapshots__/summaryTest.js.snap
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`summary global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`summary with $tag registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`summary global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`summary with $tag registry global registry with param as object labels should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
 
-exports[`summary global registry with param as object should validate labels when observing 1`] = `"Added label \\"baz\\" is not included in initial labelset: [ 'foo' ]"`;
+exports[`summary with $tag registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+
+exports[`summary with $tag registry global registry with param as object remove should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+
+exports[`summary with $tag registry global registry with param as object should validate labels when observing 1`] = `"Added label \\"baz\\" is not included in initial labelset: [ 'foo' ]"`;
+
+exports[`summary with $tag registry global registry with param as object should validate labels when observing 2`] = `"Added label \\"baz\\" is not included in initial labelset: [ 'foo' ]"`;

--- a/test/__snapshots__/summaryTest.js.snap
+++ b/test/__snapshots__/summaryTest.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`summary with $tag registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`summary with OpenMetrics registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`summary with $tag registry global registry with param as object labels should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+exports[`summary with OpenMetrics registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`summary with $tag registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
+exports[`summary with OpenMetrics registry global registry with param as object should validate labels when observing 1`] = `"Added label \\"baz\\" is not included in initial labelset: [ 'foo' ]"`;
 
-exports[`summary with $tag registry global registry with param as object remove should throw error if label lengths does not match 2`] = `"Invalid number of arguments"`;
+exports[`summary with Prometheus registry global registry with param as object labels should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`summary with $tag registry global registry with param as object should validate labels when observing 1`] = `"Added label \\"baz\\" is not included in initial labelset: [ 'foo' ]"`;
+exports[`summary with Prometheus registry global registry with param as object remove should throw error if label lengths does not match 1`] = `"Invalid number of arguments"`;
 
-exports[`summary with $tag registry global registry with param as object should validate labels when observing 2`] = `"Added label \\"baz\\" is not included in initial labelset: [ 'foo' ]"`;
+exports[`summary with Prometheus registry global registry with param as object should validate labels when observing 1`] = `"Added label \\"baz\\" is not included in initial labelset: [ 'foo' ]"`;

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -5,9 +5,9 @@ const process = require('process');
 const Registry = require('../lib/cluster');
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('$tag AggregatorRegistry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('%s AggregatorRegistry', (tag, regType) => {
 	beforeEach(() => {
 		Registry.globalRegistry.setContentType(regType);
 	});

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -2,8 +2,16 @@
 
 const cluster = require('cluster');
 const process = require('process');
+const Registry = require('../lib/cluster');
 
-describe('AggregatorRegistry', () => {
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('$tag AggregatorRegistry', ({ tag, regType }) => {
+	beforeEach(() => {
+		Registry.globalRegistry.setContentType(regType);
+	});
+
 	it('requiring the cluster should not add any listeners on the cluster module', () => {
 		const originalListenerCount = cluster.listenerCount('message');
 
@@ -35,14 +43,13 @@ describe('AggregatorRegistry', () => {
 	describe('aggregatorRegistry.clusterMetrics()', () => {
 		it('works properly if there are no cluster workers', async () => {
 			const AggregatorRegistry = require('../lib/cluster');
-			const ar = new AggregatorRegistry();
+			const ar = new AggregatorRegistry(regType);
 			const metrics = await ar.clusterMetrics();
 			expect(metrics).toEqual('');
 		});
 	});
 
 	describe('AggregatorRegistry.aggregate()', () => {
-		const Registry = require('../lib/cluster');
 		// These mimic the output of `getMetricsAsJSON`.
 		const metricsArr1 = [
 			{
@@ -159,7 +166,7 @@ describe('AggregatorRegistry', () => {
 			},
 		];
 
-		const aggregated = Registry.aggregate([metricsArr1, metricsArr2]);
+		const aggregated = Registry.aggregate([metricsArr1, metricsArr2], regType);
 
 		it('defaults to summation, preserves histogram bins', async () => {
 			const histogram = aggregated.getSingleMetric('test_histogram').get();

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('counter with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('counter with %s registry', (tag, regType) => {
 	const Counter = require('../index').Counter;
 	const globalRegistry = require('../index').register;
 	let instance;

--- a/test/counterTest.js
+++ b/test/counterTest.js
@@ -1,10 +1,18 @@
 'use strict';
 
-describe('counter', () => {
+const Registry = require('../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('counter with $tag registry', ({ tag, regType }) => {
 	const Counter = require('../index').Counter;
-	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
 	let instance;
+
+	beforeEach(() => {
+		globalRegistry.setContentType(regType);
+	});
 
 	describe('with params as object', () => {
 		beforeEach(() => {
@@ -168,7 +176,7 @@ describe('counter', () => {
 	describe('registry instance', () => {
 		let registryInstance;
 		beforeEach(() => {
-			registryInstance = new Registry();
+			registryInstance = new Registry(regType);
 			instance = new Counter({
 				name: 'gauge_test',
 				help: 'test',

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('collectDefaultMetrics with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('collectDefaultMetrics with %s registry', (tag, regType) => {
 	const register = require('../index').register;
 	const collectDefaultMetrics = require('../index').collectDefaultMetrics;
 	let cpuUsage;

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -1,8 +1,12 @@
 'use strict';
 
-describe('collectDefaultMetrics', () => {
+const Registry = require('../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('collectDefaultMetrics with $tag registry', ({ tag, regType }) => {
 	const register = require('../index').register;
-	const Registry = require('../index').Registry;
 	const collectDefaultMetrics = require('../index').collectDefaultMetrics;
 	let cpuUsage;
 
@@ -32,6 +36,10 @@ describe('collectDefaultMetrics', () => {
 		} else {
 			delete process.cpuUsage;
 		}
+	});
+
+	beforeEach(() => {
+		register.setContentType(regType);
 	});
 
 	afterEach(() => {
@@ -95,7 +103,7 @@ describe('collectDefaultMetrics', () => {
 
 	describe('custom registry', () => {
 		it('should allow to register metrics to custom registry', async () => {
-			const registry = new Registry();
+			const registry = new Registry(regType);
 
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 			expect(await registry.getMetricsAsJSON()).toHaveLength(0);

--- a/test/exemplarsTest.js
+++ b/test/exemplarsTest.js
@@ -1,108 +1,131 @@
 'use strict';
 
 const Registry = require('../index').Registry;
+const globalRegistry = require('../index').register;
+const Histogram = require('../index').Histogram;
+const Counter = require('../index').Counter;
 
-describe.each([
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('exemplars with $tag registry', ({ tag, regType }) => {
-	// create counter with exemplars
-	// create histogram with exemplars
-	// check if exemplar is populated by openTElemetry <- this should be tested in the metrics directory
-	//
-	const globalRegistry = require('../index').register;
-	const Counter = require('../index').Counter;
-	const Histogram = require('../index').Histogram;
-
-	beforeEach(() => {
-		globalRegistry.setContentType(regType);
-	});
-
-	it('should make counter with exemplar', async () => {
-		const counterInstance = new Counter({
-			name: 'counter_exemplar_test',
-			help: 'help',
-			labelNames: ['method', 'code'],
-			enableExemplars: true,
-		});
-		counterInstance.inc({
-			value: 2,
-			labels: { method: 'get', code: '200' },
-			exemplarLabels: { traceId: 'trace_id_test', spanId: 'span_id_test' },
-		});
-		const vals = await counterInstance.get();
-		expect(vals.values[0].value).toEqual(2);
-		expect(vals.values[0].exemplar.value).toEqual(2);
-		expect(vals.values[0].exemplar.labelSet.traceId).toEqual('trace_id_test');
-	});
-
-	it('should make histogram with exemplars on multiple buckets', async () => {
-		const histogramInstance = new Histogram({
-			name: 'histogram_exemplar_test',
-			help: 'test',
-			labelNames: ['method', 'code'],
-			enableExemplars: true,
-		});
-
-		histogramInstance.observe({
-			value: 0.007,
-			labels: { method: 'get', code: '200' },
-			exemplarLabels: { traceId: 'trace_id_test_1', spanId: 'span_id_test_1' },
-		});
-		histogramInstance.observe({
-			value: 0.4,
-			labels: { method: 'get', code: '200' },
-			exemplarLabels: { traceId: 'trace_id_test_2', spanId: 'span_id_test_2' },
-		});
-		histogramInstance.observe({
-			value: 11,
-			labels: { method: 'get', code: '200' },
-			exemplarLabels: { traceId: 'trace_id_test_3', spanId: 'span_id_test_3' },
-		});
-
-		const vals = (await histogramInstance.get()).values;
-
-		expect(getValuesByLabel(0.005, vals)[0].value).toEqual(0);
-		expect(getValuesByLabel(0.005, vals)[0].exemplar).toEqual(null);
-
-		expect(getValuesByLabel(0.5, vals)[0].value).toEqual(2);
-		expect(getValuesByLabel(0.5, vals)[0].exemplar.labelSet.traceId).toEqual(
-			'trace_id_test_2',
-		);
-		expect(getValuesByLabel(0.5, vals)[0].exemplar.value).toEqual(0.4);
-
-		expect(getValuesByLabel(10, vals)[0].value).toEqual(2);
-		expect(getValuesByLabel(10, vals)[0].exemplar).toEqual(null);
-
-		expect(getValuesByLabel('+Inf', vals)[0].value).toEqual(3);
-		expect(getValuesByLabel('+Inf', vals)[0].exemplar.labelSet.traceId).toEqual(
-			'trace_id_test_3',
-		);
-		expect(getValuesByLabel('+Inf', vals)[0].exemplar.value).toEqual(11);
-	});
-
-	it('should throw error if exemplar is too long', async () => {
-		const histogramInstance = new Histogram({
-			name: 'histogram_too_long_exemplar_test',
-			help: 'test',
-			labelNames: ['method', 'code'],
-			enableExemplars: true,
-		});
-
+describe('Exemplars', () => {
+	it('should throw when using with Prometheus registry', async () => {
+		globalRegistry.setContentType(Registry.PROMETHEUS_CONTENT_TYPE);
 		expect(() => {
-			histogramInstance.observe({
-				value: 0.007,
-				labels: { method: 'get', code: '200' },
-				exemplarLabels: { traceId: 'j'.repeat(100), spanId: 'j'.repeat(100) },
+			const counterInstance = new Counter({
+				name: 'counter_exemplar_test',
+				help: 'help',
+				labelNames: ['method', 'code'],
+				enableExemplars: true,
 			});
-		}).toThrowError('Label set size must be smaller than 128 UTF-8 chars');
+		}).toThrowError('Exemplars are supported only on OpenMetrics registries');
 	});
+	describe.each([['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE]])(
+		'with %s registry',
+		(tag, regType) => {
+			beforeEach(() => {
+				globalRegistry.setContentType(regType);
+			});
 
-	function getValuesByLabel(label, values, key) {
-		return values.reduce((acc, val) => {
-			if (val.labels && val.labels[key || 'le'] === label) {
-				acc.push(val);
+			it('should make counter with exemplar', async () => {
+				const counterInstance = new Counter({
+					name: 'counter_exemplar_test',
+					help: 'help',
+					labelNames: ['method', 'code'],
+					enableExemplars: true,
+				});
+				counterInstance.inc({
+					value: 2,
+					labels: { method: 'get', code: '200' },
+					exemplarLabels: { traceId: 'trace_id_test', spanId: 'span_id_test' },
+				});
+				const vals = await counterInstance.get();
+				expect(vals.values[0].value).toEqual(2);
+				expect(vals.values[0].exemplar.value).toEqual(2);
+				expect(vals.values[0].exemplar.labelSet.traceId).toEqual(
+					'trace_id_test',
+				);
+			});
+
+			it('should make histogram with exemplars on multiple buckets', async () => {
+				const histogramInstance = new Histogram({
+					name: 'histogram_exemplar_test',
+					help: 'test',
+					labelNames: ['method', 'code'],
+					enableExemplars: true,
+				});
+
+				histogramInstance.observe({
+					value: 0.007,
+					labels: { method: 'get', code: '200' },
+					exemplarLabels: {
+						traceId: 'trace_id_test_1',
+						spanId: 'span_id_test_1',
+					},
+				});
+				histogramInstance.observe({
+					value: 0.4,
+					labels: { method: 'get', code: '200' },
+					exemplarLabels: {
+						traceId: 'trace_id_test_2',
+						spanId: 'span_id_test_2',
+					},
+				});
+				histogramInstance.observe({
+					value: 11,
+					labels: { method: 'get', code: '200' },
+					exemplarLabels: {
+						traceId: 'trace_id_test_3',
+						spanId: 'span_id_test_3',
+					},
+				});
+
+				const vals = (await histogramInstance.get()).values;
+
+				expect(getValuesByLabel(0.005, vals)[0].value).toEqual(0);
+				expect(getValuesByLabel(0.005, vals)[0].exemplar).toEqual(null);
+
+				expect(getValuesByLabel(0.5, vals)[0].value).toEqual(2);
+				expect(
+					getValuesByLabel(0.5, vals)[0].exemplar.labelSet.traceId,
+				).toEqual('trace_id_test_2');
+				expect(getValuesByLabel(0.5, vals)[0].exemplar.value).toEqual(0.4);
+
+				expect(getValuesByLabel(10, vals)[0].value).toEqual(2);
+				expect(getValuesByLabel(10, vals)[0].exemplar).toEqual(null);
+
+				expect(getValuesByLabel('+Inf', vals)[0].value).toEqual(3);
+				expect(
+					getValuesByLabel('+Inf', vals)[0].exemplar.labelSet.traceId,
+				).toEqual('trace_id_test_3');
+				expect(getValuesByLabel('+Inf', vals)[0].exemplar.value).toEqual(11);
+			});
+
+			it('should throw if exemplar is too long', async () => {
+				const histogramInstance = new Histogram({
+					name: 'histogram_too_long_exemplar_test',
+					help: 'test',
+					labelNames: ['method', 'code'],
+					enableExemplars: true,
+				});
+
+				expect(() => {
+					histogramInstance.observe({
+						value: 0.007,
+						labels: { method: 'get', code: '200' },
+						exemplarLabels: {
+							traceId: 'j'.repeat(100),
+							spanId: 'j'.repeat(100),
+						},
+					});
+				}).toThrowError('Label set size must be smaller than 128 UTF-8 chars');
+			});
+
+			function getValuesByLabel(label, values, key) {
+				return values.reduce((acc, val) => {
+					if (val.labels && val.labels[key || 'le'] === label) {
+						acc.push(val);
+					}
+					return acc;
+				}, []);
 			}
-			return acc;
-		}, []);
-	}
+		},
+	);
 });

--- a/test/exemplarsTest.js
+++ b/test/exemplarsTest.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const Registry = require('../index').Registry;
+
+describe.each([
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('exemplars with $tag registry', ({ tag, regType }) => {
+	// create counter with exemplars
+	// create histogram with exemplars
+	// check if exemplar is populated by openTElemetry <- this should be tested in the metrics directory
+	//
+	const globalRegistry = require('../index').register;
+	const Counter = require('../index').Counter;
+	const Histogram = require('../index').Histogram;
+
+	beforeEach(() => {
+		globalRegistry.setContentType(regType);
+	});
+
+	it('should make counter with exemplar', async () => {
+		const counterInstance = new Counter({
+			name: 'counter_exemplar_test',
+			help: 'help',
+			labelNames: ['method', 'code'],
+			enableExemplars: true,
+		});
+		counterInstance.inc({
+			value: 2,
+			labels: { method: 'get', code: '200' },
+			exemplarLabels: { traceId: 'trace_id_test', spanId: 'span_id_test' },
+		});
+		const vals = await counterInstance.get();
+		expect(vals.values[0].value).toEqual(2);
+		expect(vals.values[0].exemplar.value).toEqual(2);
+		expect(vals.values[0].exemplar.labelSet.traceId).toEqual('trace_id_test');
+	});
+
+	it('should make histogram with exemplars on multiple buckets', async () => {
+		const histogramInstance = new Histogram({
+			name: 'histogram_exemplar_test',
+			help: 'test',
+			labelNames: ['method', 'code'],
+			enableExemplars: true,
+		});
+
+		histogramInstance.observe({
+			value: 0.007,
+			labels: { method: 'get', code: '200' },
+			exemplarLabels: { traceId: 'trace_id_test_1', spanId: 'span_id_test_1' },
+		});
+		histogramInstance.observe({
+			value: 0.4,
+			labels: { method: 'get', code: '200' },
+			exemplarLabels: { traceId: 'trace_id_test_2', spanId: 'span_id_test_2' },
+		});
+		histogramInstance.observe({
+			value: 11,
+			labels: { method: 'get', code: '200' },
+			exemplarLabels: { traceId: 'trace_id_test_3', spanId: 'span_id_test_3' },
+		});
+
+		const vals = (await histogramInstance.get()).values;
+
+		expect(getValuesByLabel(0.005, vals)[0].value).toEqual(0);
+		expect(getValuesByLabel(0.005, vals)[0].exemplar).toEqual(null);
+
+		expect(getValuesByLabel(0.5, vals)[0].value).toEqual(2);
+		expect(getValuesByLabel(0.5, vals)[0].exemplar.labelSet.traceId).toEqual(
+			'trace_id_test_2',
+		);
+		expect(getValuesByLabel(0.5, vals)[0].exemplar.value).toEqual(0.4);
+
+		expect(getValuesByLabel(10, vals)[0].value).toEqual(2);
+		expect(getValuesByLabel(10, vals)[0].exemplar).toEqual(null);
+
+		expect(getValuesByLabel('+Inf', vals)[0].value).toEqual(3);
+		expect(getValuesByLabel('+Inf', vals)[0].exemplar.labelSet.traceId).toEqual(
+			'trace_id_test_3',
+		);
+		expect(getValuesByLabel('+Inf', vals)[0].exemplar.value).toEqual(11);
+	});
+
+	it('should throw error if exemplar is too long', async () => {
+		const histogramInstance = new Histogram({
+			name: 'histogram_too_long_exemplar_test',
+			help: 'test',
+			labelNames: ['method', 'code'],
+			enableExemplars: true,
+		});
+
+		expect(() => {
+			histogramInstance.observe({
+				value: 0.007,
+				labels: { method: 'get', code: '200' },
+				exemplarLabels: { traceId: 'j'.repeat(100), spanId: 'j'.repeat(100) },
+			});
+		}).toThrowError('Label set size must be smaller than 128 UTF-8 chars');
+	});
+
+	function getValuesByLabel(label, values, key) {
+		return values.reduce((acc, val) => {
+			if (val.labels && val.labels[key || 'le'] === label) {
+				acc.push(val);
+			}
+			return acc;
+		}, []);
+	}
+});

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('gauge with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('gauge with %s registry', (tag, regType) => {
 	const Gauge = require('../index').Gauge;
 	const globalRegistry = require('../index').register;
 	let instance;

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -1,10 +1,18 @@
 'use strict';
 
-describe('gauge', () => {
+const Registry = require('../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('gauge with $tag registry', ({ tag, regType }) => {
 	const Gauge = require('../index').Gauge;
-	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
 	let instance;
+
+	beforeEach(() => {
+		globalRegistry.setContentType(regType);
+	});
 
 	describe('global registry', () => {
 		afterEach(() => {
@@ -208,7 +216,7 @@ describe('gauge', () => {
 	describe('registry instance', () => {
 		let registryInstance;
 		beforeEach(() => {
-			registryInstance = new Registry();
+			registryInstance = new Registry(regType);
 			instance = new Gauge({
 				name: 'gauge_test',
 				help: 'help',

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -1,10 +1,18 @@
 'use strict';
 
-describe('histogram', () => {
+const Registry = require('../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('histogram with $tag registry', ({ tag, regType }) => {
 	const Histogram = require('../index').Histogram;
-	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
 	let instance;
+
+	beforeEach(() => {
+		globalRegistry.setContentType(regType);
+	});
 
 	afterEach(() => {
 		instance = null;
@@ -435,7 +443,7 @@ describe('histogram', () => {
 		describe('registry instance', () => {
 			let registryInstance;
 			beforeEach(() => {
-				registryInstance = new Registry();
+				registryInstance = new Registry(regType);
 				instance = new Histogram({
 					name: 'test_histogram',
 					help: 'test',

--- a/test/histogramTest.js
+++ b/test/histogramTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('histogram with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('histogram with %s registry', (tag, regType) => {
 	const Histogram = require('../index').Histogram;
 	const globalRegistry = require('../index').register;
 	let instance;

--- a/test/metrics/eventLoopLagTest.js
+++ b/test/metrics/eventLoopLagTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('eventLoopLag with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('eventLoopLag with %s registry', (tag, regType) => {
 	const register = require('../../index').register;
 	const eventLoopLag = require('../../lib/metrics/eventLoopLag');
 
@@ -21,7 +21,7 @@ describe.each([
 		register.clear();
 	});
 
-	it('should add metric to the $tag registry', async done => {
+	it(`should add metric to the ${tag} registry`, async done => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		eventLoopLag();
 

--- a/test/metrics/eventLoopLagTest.js
+++ b/test/metrics/eventLoopLagTest.js
@@ -1,6 +1,11 @@
 'use strict';
 
-describe('eventLoopLag', () => {
+const Registry = require('../../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('eventLoopLag with $tag registry', ({ tag, regType }) => {
 	const register = require('../../index').register;
 	const eventLoopLag = require('../../lib/metrics/eventLoopLag');
 
@@ -8,11 +13,15 @@ describe('eventLoopLag', () => {
 		register.clear();
 	});
 
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
+
 	afterEach(() => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', async done => {
+	it('should add metric to the $tag registry', async done => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		eventLoopLag();
 

--- a/test/metrics/gcTest.js
+++ b/test/metrics/gcTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('gc with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('gc with %s registry', (tag, regType) => {
 	const register = require('../../index').register;
 	const processHandles = require('../../lib/metrics/gc');
 
@@ -21,7 +21,7 @@ describe.each([
 		register.clear();
 	});
 
-	it('should add metric to the $tag registry', async () => {
+	it(`should add metric to the ${tag} registry`, async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		processHandles();

--- a/test/metrics/gcTest.js
+++ b/test/metrics/gcTest.js
@@ -1,6 +1,11 @@
 'use strict';
 
-describe('gc', () => {
+const Registry = require('../../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('gc with $tag registry', ({ tag, regType }) => {
 	const register = require('../../index').register;
 	const processHandles = require('../../lib/metrics/gc');
 
@@ -8,11 +13,15 @@ describe('gc', () => {
 		register.clear();
 	});
 
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
+
 	afterEach(() => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', async () => {
+	it('should add metric to the $tag registry', async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		processHandles();

--- a/test/metrics/heapSizeAndUsedTest.js
+++ b/test/metrics/heapSizeAndUsedTest.js
@@ -1,9 +1,18 @@
 'use strict';
 
-describe('heapSizeAndUsed', () => {
+const Registry = require('../../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('heapSizeAndUsed with $tag registry', ({ tag, regType }) => {
 	const heapSizeAndUsed = require('../../lib/metrics/heapSizeAndUsed');
 	const globalRegistry = require('../../lib/registry').globalRegistry;
 	const memoryUsedFn = process.memoryUsage;
+
+	beforeEach(() => {
+		globalRegistry.setContentType(regType);
+	});
 
 	afterEach(() => {
 		process.memoryUsage = memoryUsedFn;

--- a/test/metrics/heapSizeAndUsedTest.js
+++ b/test/metrics/heapSizeAndUsedTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('heapSizeAndUsed with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('heapSizeAndUsed with %s registry', (tag, regType) => {
 	const heapSizeAndUsed = require('../../lib/metrics/heapSizeAndUsed');
 	const globalRegistry = require('../../lib/registry').globalRegistry;
 	const memoryUsedFn = process.memoryUsage;

--- a/test/metrics/heapSpacesSizeAndUsedTest.js
+++ b/test/metrics/heapSpacesSizeAndUsedTest.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Registry = require('../../index').Registry;
+
 jest.mock('v8', () => {
 	return {
 		getHeapSpaceStatistics() {
@@ -44,19 +46,23 @@ jest.mock('v8', () => {
 	};
 });
 
-describe('heapSpacesSizeAndUsed', () => {
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('heapSpacesSizeAndUsed with $tag registry', ({ tag, regType }) => {
 	let heapSpacesSizeAndUsed;
 	const globalRegistry = require('../../lib/registry').globalRegistry;
 
 	beforeEach(() => {
 		heapSpacesSizeAndUsed = require('../../lib/metrics/heapSpacesSizeAndUsed');
+		globalRegistry.setContentType(regType);
 	});
 
 	afterEach(() => {
 		globalRegistry.clear();
 	});
 
-	it('should set total heap spaces size gauges with values from v8', async () => {
+	it('should set total heap spaces size gauges with values from v8 with $tag registry', async () => {
 		expect(await globalRegistry.getMetricsAsJSON()).toHaveLength(0);
 
 		heapSpacesSizeAndUsed();

--- a/test/metrics/heapSpacesSizeAndUsedTest.js
+++ b/test/metrics/heapSpacesSizeAndUsedTest.js
@@ -47,9 +47,9 @@ jest.mock('v8', () => {
 });
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('heapSpacesSizeAndUsed with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('heapSpacesSizeAndUsed with %s registry', (tag, regType) => {
 	let heapSpacesSizeAndUsed;
 	const globalRegistry = require('../../lib/registry').globalRegistry;
 
@@ -62,7 +62,7 @@ describe.each([
 		globalRegistry.clear();
 	});
 
-	it('should set total heap spaces size gauges with values from v8 with $tag registry', async () => {
+	it(`should set total heap spaces size gauges with values from v8 with ${tag} registry`, async () => {
 		expect(await globalRegistry.getMetricsAsJSON()).toHaveLength(0);
 
 		heapSpacesSizeAndUsed();

--- a/test/metrics/maxFileDescriptorsTest.js
+++ b/test/metrics/maxFileDescriptorsTest.js
@@ -4,9 +4,9 @@ const exec = require('child_process').execSync;
 const Registry = require('../../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('processMaxFileDescriptors with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('processMaxFileDescriptors with %s registry', (tag, regType) => {
 	const register = require('../../index').register;
 	const processMaxFileDescriptors = require('../../lib/metrics/processMaxFileDescriptors');
 
@@ -23,7 +23,7 @@ describe.each([
 	});
 
 	if (process.platform !== 'linux') {
-		it('should not add metric to the $tag registry', async () => {
+		it(`should not add metric to the ${tag} registry`, async () => {
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 			processMaxFileDescriptors();
@@ -31,7 +31,7 @@ describe.each([
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		});
 	} else {
-		it('should add metric to the $tag registry', async () => {
+		it(`should add metric to the ${tag} registry`, async () => {
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 			processMaxFileDescriptors();
@@ -47,7 +47,7 @@ describe.each([
 			expect(metrics[0].values).toHaveLength(1);
 		});
 
-		it('should have a reasonable metric value with $tag registry', async () => {
+		it(`should have a reasonable metric value with ${tag} registry`, async () => {
 			const maxFiles = Number(exec('ulimit -Hn', { encoding: 'utf8' }));
 
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);

--- a/test/metrics/maxFileDescriptorsTest.js
+++ b/test/metrics/maxFileDescriptorsTest.js
@@ -1,8 +1,12 @@
 'use strict';
 
 const exec = require('child_process').execSync;
+const Registry = require('../../index').Registry;
 
-describe('processMaxFileDescriptors', () => {
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('processMaxFileDescriptors with $tag registry', ({ tag, regType }) => {
 	const register = require('../../index').register;
 	const processMaxFileDescriptors = require('../../lib/metrics/processMaxFileDescriptors');
 
@@ -10,12 +14,16 @@ describe('processMaxFileDescriptors', () => {
 		register.clear();
 	});
 
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
+
 	afterEach(() => {
 		register.clear();
 	});
 
 	if (process.platform !== 'linux') {
-		it('should not add metric to the registry', async () => {
+		it('should not add metric to the $tag registry', async () => {
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 			processMaxFileDescriptors();
@@ -23,7 +31,7 @@ describe('processMaxFileDescriptors', () => {
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		});
 	} else {
-		it('should add metric to the registry', async () => {
+		it('should add metric to the $tag registry', async () => {
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 			processMaxFileDescriptors();
@@ -39,7 +47,7 @@ describe('processMaxFileDescriptors', () => {
 			expect(metrics[0].values).toHaveLength(1);
 		});
 
-		it('should have a reasonable metric value', async () => {
+		it('should have a reasonable metric value with $tag registry', async () => {
 			const maxFiles = Number(exec('ulimit -Hn', { encoding: 'utf8' }));
 
 			expect(await register.getMetricsAsJSON()).toHaveLength(0);

--- a/test/metrics/processHandlesTest.js
+++ b/test/metrics/processHandlesTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('processHandles with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('processHandles with %s registry', (tag, regType) => {
 	const register = require('../../index').register;
 	const processHandles = require('../../lib/metrics/processHandles');
 
@@ -21,7 +21,7 @@ describe.each([
 		register.clear();
 	});
 
-	it('should add metric to the $tag registry', async () => {
+	it(`should add metric to the ${tag} registry`, async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		processHandles();

--- a/test/metrics/processHandlesTest.js
+++ b/test/metrics/processHandlesTest.js
@@ -1,6 +1,11 @@
 'use strict';
 
-describe('processHandles', () => {
+const Registry = require('../../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('processHandles with $tag registry', ({ tag, regType }) => {
 	const register = require('../../index').register;
 	const processHandles = require('../../lib/metrics/processHandles');
 
@@ -8,11 +13,15 @@ describe('processHandles', () => {
 		register.clear();
 	});
 
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
+
 	afterEach(() => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', async () => {
+	it('should add metric to the $tag registry', async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		processHandles();

--- a/test/metrics/processOpenFileDescriptorsTest.js
+++ b/test/metrics/processOpenFileDescriptorsTest.js
@@ -1,24 +1,32 @@
 'use strict';
 
-describe('processOpenFileDescriptors', () => {
+const Registry = require('../../index').Registry;
+
+jest.mock(
+	'process',
+	() => Object.assign({}, jest.requireActual('process'), { platform: 'linux' }), // This metric only works on Linux
+);
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('processOpenFileDescriptors with $tag registry', ({ tag, regType }) => {
 	const register = require('../../index').register;
 	const processOpenFileDescriptors = require('../../lib/metrics/processOpenFileDescriptors');
 
-	jest.mock(
-		'process',
-		() =>
-			Object.assign({}, jest.requireActual('process'), { platform: 'linux' }), // This metric only works on Linux
-	);
-
 	beforeAll(() => {
 		register.clear();
+	});
+
+	beforeEach(() => {
+		register.setContentType(regType);
 	});
 
 	afterEach(() => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', async () => {
+	it('should add metric to the $tag registry', async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		processOpenFileDescriptors();

--- a/test/metrics/processOpenFileDescriptorsTest.js
+++ b/test/metrics/processOpenFileDescriptorsTest.js
@@ -8,9 +8,9 @@ jest.mock(
 );
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('processOpenFileDescriptors with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('processOpenFileDescriptors with %s registry', (tag, regType) => {
 	const register = require('../../index').register;
 	const processOpenFileDescriptors = require('../../lib/metrics/processOpenFileDescriptors');
 
@@ -26,7 +26,7 @@ describe.each([
 		register.clear();
 	});
 
-	it('should add metric to the $tag registry', async () => {
+	it(`should add metric to the ${tag} registry`, async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		processOpenFileDescriptors();

--- a/test/metrics/processRequestsTest.js
+++ b/test/metrics/processRequestsTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('processRequests with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('processRequests with %s registry', (tag, regType) => {
 	const register = require('../../index').register;
 	const processRequests = require('../../lib/metrics/processRequests');
 
@@ -21,7 +21,7 @@ describe.each([
 		register.clear();
 	});
 
-	it('should add metric to the $tag registry', async () => {
+	it(`should add metric to the ${tag} registry`, async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		processRequests();

--- a/test/metrics/processRequestsTest.js
+++ b/test/metrics/processRequestsTest.js
@@ -1,6 +1,11 @@
 'use strict';
 
-describe('processRequests', () => {
+const Registry = require('../../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('processRequests with $tag registry', ({ tag, regType }) => {
 	const register = require('../../index').register;
 	const processRequests = require('../../lib/metrics/processRequests');
 
@@ -8,11 +13,15 @@ describe('processRequests', () => {
 		register.clear();
 	});
 
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
+
 	afterEach(() => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', async () => {
+	it('should add metric to the $tag registry', async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		processRequests();

--- a/test/metrics/processStartTimeTest.js
+++ b/test/metrics/processStartTimeTest.js
@@ -1,6 +1,11 @@
 'use strict';
 
-describe('processStartTime', () => {
+const Registry = require('../../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('processStartTime with $tag registry', ({ tag, regType }) => {
 	const register = require('../../index').register;
 	const op = require('../../lib/metrics/processStartTime');
 
@@ -8,11 +13,15 @@ describe('processStartTime', () => {
 		register.clear();
 	});
 
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
+
 	afterEach(() => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', async () => {
+	it('should add metric to the $tag registry', async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		op();

--- a/test/metrics/processStartTimeTest.js
+++ b/test/metrics/processStartTimeTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('processStartTime with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('processStartTime with %s registry', (tag, regType) => {
 	const register = require('../../index').register;
 	const op = require('../../lib/metrics/processStartTime');
 
@@ -21,7 +21,7 @@ describe.each([
 		register.clear();
 	});
 
-	it('should add metric to the $tag registry', async () => {
+	it(`should add metric to the ${tag} registry`, async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 
 		op();

--- a/test/metrics/versionTest.js
+++ b/test/metrics/versionTest.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Registry = require('../../index').Registry;
 const nodeVersion = process.version;
 const versionSegments = nodeVersion.slice(1).split('.').map(Number);
 
@@ -15,7 +16,10 @@ function expectVersionMetrics(metrics) {
 	expect(metrics[0].values[0].labels.patch).toEqual(versionSegments[2]);
 }
 
-describe('version', () => {
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('version with $tag registry', ({ tag, regType }) => {
 	const register = require('../../index').register;
 	const version = require('../../lib/metrics/version');
 
@@ -23,11 +27,15 @@ describe('version', () => {
 		register.clear();
 	});
 
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
+
 	afterEach(() => {
 		register.clear();
 	});
 
-	it('should add metric to the registry', async () => {
+	it('should add metric to the $tag registry', async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		expect(typeof versionSegments[0]).toEqual('number');
 		expect(typeof versionSegments[1]).toEqual('number');
@@ -39,7 +47,7 @@ describe('version', () => {
 		expectVersionMetrics(metrics);
 	});
 
-	it('should still be present after resetting the registry #238', async () => {
+	it('should still be present after resetting the $tag registry #238', async () => {
 		const collector = version();
 		expectVersionMetrics(await register.getMetricsAsJSON());
 		register.resetMetrics();

--- a/test/metrics/versionTest.js
+++ b/test/metrics/versionTest.js
@@ -17,9 +17,9 @@ function expectVersionMetrics(metrics) {
 }
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('version with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('version with %s registry', (tag, regType) => {
 	const register = require('../../index').register;
 	const version = require('../../lib/metrics/version');
 
@@ -35,7 +35,7 @@ describe.each([
 		register.clear();
 	});
 
-	it('should add metric to the $tag registry', async () => {
+	it(`should add metric to the ${tag} registry`, async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		expect(typeof versionSegments[0]).toEqual('number');
 		expect(typeof versionSegments[1]).toEqual('number');
@@ -47,7 +47,7 @@ describe.each([
 		expectVersionMetrics(metrics);
 	});
 
-	it('should still be present after resetting the $tag registry #238', async () => {
+	it(`should still be present after resetting the ${tag} registry #238`, async () => {
 		const collector = version();
 		expectVersionMetrics(await register.getMetricsAsJSON());
 		register.resetMetrics();

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -3,12 +3,20 @@
 const nock = require('nock');
 const { gzipSync } = require('zlib');
 
-describe('pushgateway', () => {
+const Registry = require('../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	// { tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('pushgateway with $tag registry', ({ tag, regType }) => {
 	const Pushgateway = require('../index').Pushgateway;
 	const register = require('../index').register;
-	const Registry = require('../index').Registry;
 	let instance;
 	let registry = undefined;
+
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
 
 	const tests = function () {
 		describe('pushAdd', () => {
@@ -229,7 +237,7 @@ describe('pushgateway', () => {
 		});
 
 		beforeEach(() => {
-			registry = new Registry();
+			registry = new Registry(regType);
 			instance = new Pushgateway('http://192.168.99.100:9091', null, registry);
 			const promeClient = require('../index');
 			const cnt = new promeClient.Counter({

--- a/test/pushgatewayTest.js
+++ b/test/pushgatewayTest.js
@@ -6,9 +6,9 @@ const { gzipSync } = require('zlib');
 const Registry = require('../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	// { tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('pushgateway with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('pushgateway with %s registry', (tag, regType) => {
 	const Pushgateway = require('../index').Pushgateway;
 	const register = require('../index').register;
 	let instance;
@@ -19,13 +19,17 @@ describe.each([
 	});
 
 	const tests = function () {
+		let body;
+		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+			body = '# HELP test test\n# TYPE test counter\ntest_total 100\n# EOF\n';
+		} else {
+			body = '# HELP test test\n# TYPE test counter\ntest 100\n';
+		}
+
 		describe('pushAdd', () => {
 			it('should push metrics', () => {
 				const mockHttp = nock('http://192.168.99.100:9091')
-					.post(
-						'/metrics/job/testJob',
-						'# HELP test test\n# TYPE test counter\ntest 100\n',
-					)
+					.post('/metrics/job/testJob', body)
 					.reply(200);
 
 				return instance.pushAdd({ jobName: 'testJob' }).then(() => {
@@ -35,10 +39,7 @@ describe.each([
 
 			it('should use groupings', () => {
 				const mockHttp = nock('http://192.168.99.100:9091')
-					.post(
-						'/metrics/job/testJob/key/value',
-						'# HELP test test\n# TYPE test counter\ntest 100\n',
-					)
+					.post('/metrics/job/testJob/key/value', body)
 					.reply(200);
 
 				return instance
@@ -53,10 +54,7 @@ describe.each([
 
 			it('should escape groupings', () => {
 				const mockHttp = nock('http://192.168.99.100:9091')
-					.post(
-						'/metrics/job/testJob/key/va%26lue',
-						'# HELP test test\n# TYPE test counter\ntest 100\n',
-					)
+					.post('/metrics/job/testJob/key/va%26lue', body)
 					.reply(200);
 
 				return instance
@@ -73,10 +71,7 @@ describe.each([
 		describe('push', () => {
 			it('should push with PUT', () => {
 				const mockHttp = nock('http://192.168.99.100:9091')
-					.put(
-						'/metrics/job/testJob',
-						'# HELP test test\n# TYPE test counter\ntest 100\n',
-					)
+					.put('/metrics/job/testJob', body)
 					.reply(200);
 
 				return instance.push({ jobName: 'testJob' }).then(() => {
@@ -86,10 +81,7 @@ describe.each([
 
 			it('should uri encode url', () => {
 				const mockHttp = nock('http://192.168.99.100:9091')
-					.put(
-						'/metrics/job/test%26Job',
-						'# HELP test test\n# TYPE test counter\ntest 100\n',
-					)
+					.put('/metrics/job/test%26Job', body)
 					.reply(200);
 
 				return instance.push({ jobName: 'test&Job' }).then(() => {
@@ -125,10 +117,7 @@ describe.each([
 
 			it('pushAdd should send POST request with basic auth data', () => {
 				const mockHttp = nock(`http://${auth}@192.168.99.100:9091`)
-					.post(
-						'/metrics/job/testJob',
-						'# HELP test test\n# TYPE test counter\ntest 100\n',
-					)
+					.post('/metrics/job/testJob', body)
 					.reply(200);
 
 				return instance.pushAdd({ jobName: 'testJob' }).then(() => {
@@ -138,10 +127,7 @@ describe.each([
 
 			it('push should send PUT request with basic auth data', () => {
 				const mockHttp = nock(`http://${auth}@192.168.99.100:9091`)
-					.put(
-						'/metrics/job/testJob',
-						'# HELP test test\n# TYPE test counter\ntest 100\n',
-					)
+					.put('/metrics/job/testJob', body)
 					.reply(200);
 
 				return instance.push({ jobName: 'testJob' }).then(() => {
@@ -166,10 +152,7 @@ describe.each([
 					'unit-test': '1',
 				},
 			})
-				.put(
-					'/metrics/job/testJob',
-					'# HELP test test\n# TYPE test counter\ntest 100\n',
-				)
+				.put('/metrics/job/testJob', body)
 				.reply(200);
 
 			instance = new Pushgateway(

--- a/test/pushgatewayWithPathTest.js
+++ b/test/pushgatewayWithPathTest.js
@@ -16,12 +16,20 @@ jest.mock('http', () => {
 	};
 });
 
-describe('pushgateway with path', () => {
+const Registry = require('../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('pushgateway with path and $tag registry', ({ tag, regType }) => {
 	const Pushgateway = require('../index').Pushgateway;
 	const register = require('../index').register;
-	const Registry = require('../index').Registry;
 	let instance;
 	let registry = undefined;
+
+	beforeEach(() => {
+		register.setContentType(regType);
+	});
 
 	const tests = function () {
 		describe('pushAdd', () => {
@@ -164,7 +172,7 @@ describe('pushgateway with path', () => {
 			mockHttp.mockClear();
 		});
 		beforeEach(() => {
-			registry = new Registry();
+			registry = new Registry(regType);
 			instance = new Pushgateway(pushGatewayFullURL, null, registry);
 			const promClient = require('../index');
 			const cnt = new promClient.Counter({

--- a/test/pushgatewayWithPathTest.js
+++ b/test/pushgatewayWithPathTest.js
@@ -19,9 +19,9 @@ jest.mock('http', () => {
 const Registry = require('../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('pushgateway with path and $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('pushgateway with path and %s registry', (tag, regType) => {
 	const Pushgateway = require('../index').Pushgateway;
 	const register = require('../index').register;
 	let instance;

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -1,705 +1,736 @@
 'use strict';
 
 const Registry = require('../index').Registry;
+const register = require('../index').register;
 
-describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('$tag register', ({ tag, regType }) => {
-	const register = require('../index').register;
-	const Counter = require('../index').Counter;
-	const Gauge = require('../index').Gauge;
-	const Histogram = require('../index').Histogram;
-	const Summary = require('../index').Summary;
-
-	beforeEach(() => {
-		register.setContentType(regType);
-		register.clear();
-	});
-
-	describe('should output a counter metric', () => {
-		let output;
-		beforeEach(async () => {
-			register.registerMetric(getMetric());
-			output = (await register.metrics()).split('\n');
-		});
-
-		it('with help as first item', () => {
-			expect(output[0]).toEqual('# HELP test_metric A test metric');
-		});
-		it('with type as second item', () => {
-			expect(output[1]).toEqual('# TYPE test_metric counter');
-		});
-		it('with first value of the metric as third item', () => {
-			if (register.contentType === Registry.OPENMETRICS_CONTENT_TYPE) {
-				expect(output[2]).toEqual(
-					'test_metric_total{label="hello",code="303"} 12',
-				);
-			} else {
-				expect(output[2]).toEqual('test_metric{label="hello",code="303"} 12');
-			}
-		});
-		it('with second value of the metric as fourth item', () => {
-			if (register.contentType === Registry.OPENMETRICS_CONTENT_TYPE) {
-				expect(output[3]).toEqual(
-					'test_metric_total{label="bye",code="404"} 34',
-				);
-			} else {
-				expect(output[3]).toEqual('test_metric{label="bye",code="404"} 34');
-			}
-		});
-	});
-
-	it('should throw on more than one metric', () => {
-		register.registerMetric(getMetric());
-
+describe('Register', () => {
+	it('should throw if set to an unsupported type', () => {
 		expect(() => {
+			register.setContentType(
+				'application/openmetrics-text; version=42.0.0; charset=utf-8',
+			);
+		}).toThrowError('Content type unsupported');
+	});
+
+	it('should throw if created with an unsupported type', () => {
+		expect(() => {
+			new Registry(
+				'application/openmetrics-text; version=42.0.0; charset=utf-8',
+			);
+		}).toThrowError('Content type unsupported');
+	});
+
+	describe.each([
+		['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+		['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+	])('with %s type', (tag, regType) => {
+		const Counter = require('../index').Counter;
+		const Gauge = require('../index').Gauge;
+		const Histogram = require('../index').Histogram;
+		const Summary = require('../index').Summary;
+
+		beforeEach(() => {
+			register.setContentType(regType);
+			register.clear();
+		});
+
+		describe('should output a counter metric', () => {
+			let output;
+			beforeEach(async () => {
+				register.registerMetric(getMetric());
+				output = (await register.metrics()).split('\n');
+			});
+
+			it('with help as first item', () => {
+				expect(output[0]).toEqual('# HELP test_metric A test metric');
+			});
+			it('with type as second item', () => {
+				expect(output[1]).toEqual('# TYPE test_metric counter');
+			});
+			it('with first value of the metric as third item', () => {
+				if (register.contentType === Registry.OPENMETRICS_CONTENT_TYPE) {
+					expect(output[2]).toEqual(
+						'test_metric_total{label="hello",code="303"} 12',
+					);
+				} else {
+					expect(output[2]).toEqual('test_metric{label="hello",code="303"} 12');
+				}
+			});
+			it('with second value of the metric as fourth item', () => {
+				if (register.contentType === Registry.OPENMETRICS_CONTENT_TYPE) {
+					expect(output[3]).toEqual(
+						'test_metric_total{label="bye",code="404"} 34',
+					);
+				} else {
+					expect(output[3]).toEqual('test_metric{label="bye",code="404"} 34');
+				}
+			});
+		});
+
+		it('should throw on more than one metric', () => {
 			register.registerMetric(getMetric());
-		}).toThrowError(
-			'A metric with the name test_metric has already been registered.',
-		);
-	});
 
-	it('should handle and output a metric with a NaN value', async () => {
-		register.registerMetric({
-			async get() {
-				return {
-					name: 'test_metric',
-					type: 'gauge',
-					help: 'A test metric',
-					values: [
-						{
-							value: NaN,
-						},
-					],
-				};
-			},
-		});
-		const lines = (await register.metrics()).split('\n');
-		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			expect(lines).toHaveLength(5);
-		} else {
-			expect(lines).toHaveLength(4);
-		}
-		expect(lines[2]).toEqual('test_metric Nan');
-	});
-
-	it('should handle and output a metric with an +Infinity value', async () => {
-		register.registerMetric({
-			async get() {
-				return {
-					name: 'test_metric',
-					type: 'gauge',
-					help: 'A test metric',
-					values: [
-						{
-							value: Infinity,
-						},
-					],
-				};
-			},
-		});
-		const lines = (await register.metrics()).split('\n');
-		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			expect(lines).toHaveLength(5);
-		} else {
-			expect(lines).toHaveLength(4);
-		}
-		expect(lines[2]).toEqual('test_metric +Inf');
-	});
-
-	it('should handle and output a metric with an -Infinity value', async () => {
-		register.registerMetric({
-			async get() {
-				return {
-					name: 'test_metric',
-					type: 'gauge',
-					help: 'A test metric',
-					values: [
-						{
-							value: -Infinity,
-						},
-					],
-				};
-			},
-		});
-		const lines = (await register.metrics()).split('\n');
-		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			expect(lines).toHaveLength(5);
-		} else {
-			expect(lines).toHaveLength(4);
-		}
-		expect(lines[2]).toEqual('test_metric -Inf');
-	});
-
-	it('should handle a metric without labels', async () => {
-		register.registerMetric({
-			async get() {
-				return {
-					name: 'test_metric',
-					type: 'counter',
-					help: 'A test metric',
-					values: [
-						{
-							value: 1,
-						},
-					],
-				};
-			},
-		});
-		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			expect((await register.metrics()).split('\n')).toHaveLength(5);
-		} else {
-			expect((await register.metrics()).split('\n')).toHaveLength(4);
-		}
-	});
-
-	it('should handle a metric with default labels', async () => {
-		register.setDefaultLabels({ testLabel: 'testValue' });
-		register.registerMetric({
-			async get() {
-				return {
-					name: 'test_metric',
-					type: 'counter',
-					help: 'A test metric',
-					values: [{ value: 1 }],
-				};
-			},
-		});
-
-		const output = (await register.metrics()).split('\n')[2];
-		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			expect(output).toEqual('test_metric_total{testLabel="testValue"} 1');
-		} else {
-			expect(output).toEqual('test_metric{testLabel="testValue"} 1');
-		}
-	});
-
-	it('labeled metrics should take precidence over defaulted', async () => {
-		register.setDefaultLabels({ testLabel: 'testValue' });
-		register.registerMetric({
-			async get() {
-				return {
-					name: 'test_metric',
-					type: 'counter',
-					help: 'A test metric',
-					values: [
-						{
-							value: 1,
-							labels: {
-								testLabel: 'overlapped',
-								anotherLabel: 'value123',
-							},
-						},
-					],
-				};
-			},
-		});
-
-		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			expect((await register.metrics()).split('\n')[2]).toEqual(
-				'test_metric_total{testLabel="overlapped",anotherLabel="value123"} 1',
+			expect(() => {
+				register.registerMetric(getMetric());
+			}).toThrowError(
+				'A metric with the name test_metric has already been registered.',
 			);
-		} else {
-			expect((await register.metrics()).split('\n')[2]).toEqual(
-				'test_metric{testLabel="overlapped",anotherLabel="value123"} 1',
-			);
-		}
-	});
+		});
 
-	it('should output all initialized metrics at value 0', async () => {
-		new Counter({ name: 'counter', help: 'help' });
-		new Gauge({ name: 'gauge', help: 'help' });
-		new Histogram({ name: 'histogram', help: 'help' });
-		new Summary({ name: 'summary', help: 'help' });
-
-		expect(await register.metrics()).toMatchSnapshot();
-	});
-
-	it('should not output all initialized metrics at value 0 if labels', async () => {
-		new Counter({ name: 'counter', help: 'help', labelNames: ['label'] });
-		new Gauge({ name: 'gauge', help: 'help', labelNames: ['label'] });
-		new Histogram({ name: 'histogram', help: 'help', labelNames: ['label'] });
-		new Summary({ name: 'summary', help: 'help', labelNames: ['label'] });
-
-		expect(await register.metrics()).toMatchSnapshot();
-	});
-
-	describe('should escape', () => {
-		let escapedResult;
-		beforeEach(async () => {
+		it('should handle and output a metric with a NaN value', async () => {
 			register.registerMetric({
 				async get() {
 					return {
-						name: 'test_"_\\_\n_metric',
-						help: 'help_help',
-						type: 'counter',
+						name: 'test_metric',
+						type: 'gauge',
+						help: 'A test metric',
+						values: [
+							{
+								value: NaN,
+							},
+						],
 					};
 				},
 			});
-			escapedResult = await register.metrics();
+			const lines = (await register.metrics()).split('\n');
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect(lines).toHaveLength(5);
+			} else {
+				expect(lines).toHaveLength(4);
+			}
+			expect(lines[2]).toEqual('test_metric Nan');
 		});
-		it('backslash to \\\\', () => {
-			expect(escapedResult).toMatch(/\\\\/);
-		});
-		it('newline to \\\\n', () => {
-			expect(escapedResult).toMatch(/\n/);
-		});
-	});
 
-	it('should escape " in label values', async () => {
-		register.registerMetric({
-			async get() {
-				return {
-					name: 'test_metric',
-					type: 'counter',
-					help: 'A test metric',
-					values: [
-						{
-							value: 12,
-							labels: {
-								label: 'hello',
-								code: '3"03',
+		it('should handle and output a metric with an +Infinity value', async () => {
+			register.registerMetric({
+				async get() {
+					return {
+						name: 'test_metric',
+						type: 'gauge',
+						help: 'A test metric',
+						values: [
+							{
+								value: Infinity,
 							},
-						},
-					],
+						],
+					};
+				},
+			});
+			const lines = (await register.metrics()).split('\n');
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect(lines).toHaveLength(5);
+			} else {
+				expect(lines).toHaveLength(4);
+			}
+			expect(lines[2]).toEqual('test_metric +Inf');
+		});
+
+		it('should handle and output a metric with an -Infinity value', async () => {
+			register.registerMetric({
+				async get() {
+					return {
+						name: 'test_metric',
+						type: 'gauge',
+						help: 'A test metric',
+						values: [
+							{
+								value: -Infinity,
+							},
+						],
+					};
+				},
+			});
+			const lines = (await register.metrics()).split('\n');
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect(lines).toHaveLength(5);
+			} else {
+				expect(lines).toHaveLength(4);
+			}
+			expect(lines[2]).toEqual('test_metric -Inf');
+		});
+
+		it('should handle a metric without labels', async () => {
+			register.registerMetric({
+				async get() {
+					return {
+						name: 'test_metric',
+						type: 'counter',
+						help: 'A test metric',
+						values: [
+							{
+								value: 1,
+							},
+						],
+					};
+				},
+			});
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect((await register.metrics()).split('\n')).toHaveLength(5);
+			} else {
+				expect((await register.metrics()).split('\n')).toHaveLength(4);
+			}
+		});
+
+		it('should handle a metric with default labels', async () => {
+			register.setDefaultLabels({ testLabel: 'testValue' });
+			register.registerMetric({
+				async get() {
+					return {
+						name: 'test_metric',
+						type: 'counter',
+						help: 'A test metric',
+						values: [{ value: 1 }],
+					};
+				},
+			});
+
+			const output = (await register.metrics()).split('\n')[2];
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect(output).toEqual('test_metric_total{testLabel="testValue"} 1');
+			} else {
+				expect(output).toEqual('test_metric{testLabel="testValue"} 1');
+			}
+		});
+
+		it('labeled metrics should take precidence over defaulted', async () => {
+			register.setDefaultLabels({ testLabel: 'testValue' });
+			register.registerMetric({
+				async get() {
+					return {
+						name: 'test_metric',
+						type: 'counter',
+						help: 'A test metric',
+						values: [
+							{
+								value: 1,
+								labels: {
+									testLabel: 'overlapped',
+									anotherLabel: 'value123',
+								},
+							},
+						],
+					};
+				},
+			});
+
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect((await register.metrics()).split('\n')[2]).toEqual(
+					'test_metric_total{testLabel="overlapped",anotherLabel="value123"} 1',
+				);
+			} else {
+				expect((await register.metrics()).split('\n')[2]).toEqual(
+					'test_metric{testLabel="overlapped",anotherLabel="value123"} 1',
+				);
+			}
+		});
+
+		it('should output all initialized metrics at value 0', async () => {
+			new Counter({ name: 'counter', help: 'help' });
+			new Gauge({ name: 'gauge', help: 'help' });
+			new Histogram({ name: 'histogram', help: 'help' });
+			new Summary({ name: 'summary', help: 'help' });
+
+			expect(await register.metrics()).toMatchSnapshot();
+		});
+
+		it('should not output all initialized metrics at value 0 if labels', async () => {
+			new Counter({ name: 'counter', help: 'help', labelNames: ['label'] });
+			new Gauge({ name: 'gauge', help: 'help', labelNames: ['label'] });
+			new Histogram({ name: 'histogram', help: 'help', labelNames: ['label'] });
+			new Summary({ name: 'summary', help: 'help', labelNames: ['label'] });
+
+			expect(await register.metrics()).toMatchSnapshot();
+		});
+
+		describe('should escape', () => {
+			let escapedResult;
+			beforeEach(async () => {
+				register.registerMetric({
+					async get() {
+						return {
+							name: 'test_"_\\_\n_metric',
+							help: 'help_help',
+							type: 'counter',
+						};
+					},
+				});
+				escapedResult = await register.metrics();
+			});
+			it('backslash to \\\\', () => {
+				expect(escapedResult).toMatch(/\\\\/);
+			});
+			it('newline to \\\\n', () => {
+				expect(escapedResult).toMatch(/\n/);
+			});
+		});
+
+		it('should escape " in label values', async () => {
+			register.registerMetric({
+				async get() {
+					return {
+						name: 'test_metric',
+						type: 'counter',
+						help: 'A test metric',
+						values: [
+							{
+								value: 12,
+								labels: {
+									label: 'hello',
+									code: '3"03',
+								},
+							},
+						],
+					};
+				},
+			});
+			const escapedResult = await register.metrics();
+			expect(escapedResult).toMatch(/\\"/);
+		});
+
+		describe('should output metrics as JSON', () => {
+			it('should output metrics as JSON', async () => {
+				register.registerMetric(getMetric());
+				const output = await register.getMetricsAsJSON();
+
+				expect(output.length).toEqual(1);
+				expect(output[0].name).toEqual('test_metric');
+				expect(output[0].type).toEqual('counter');
+				expect(output[0].help).toEqual('A test metric');
+				expect(output[0].values.length).toEqual(2);
+			});
+
+			it('should add default labels to JSON', async () => {
+				register.registerMetric(getMetric());
+				register.setDefaultLabels({
+					defaultRegistryLabel: 'testValue',
+				});
+				const output = await register.getMetricsAsJSON();
+
+				expect(output.length).toEqual(1);
+				expect(output[0].name).toEqual('test_metric');
+				expect(output[0].type).toEqual('counter');
+				expect(output[0].help).toEqual('A test metric');
+				expect(output[0].values.length).toEqual(2);
+				expect(output[0].values[0].labels).toEqual({
+					code: '303',
+					label: 'hello',
+					defaultRegistryLabel: 'testValue',
+				});
+			});
+		});
+
+		it('should allow removing single metrics', async () => {
+			register.registerMetric(getMetric());
+			register.registerMetric(getMetric('some other name'));
+
+			let output = await register.getMetricsAsJSON();
+			expect(output.length).toEqual(2);
+
+			register.removeSingleMetric('test_metric');
+
+			output = await register.getMetricsAsJSON();
+
+			expect(output.length).toEqual(1);
+			expect(output[0].name).toEqual('some other name');
+		});
+
+		it('should allow getting single metrics', () => {
+			const metric = getMetric();
+			register.registerMetric(metric);
+
+			const output = register.getSingleMetric('test_metric');
+			expect(output).toEqual(metric);
+		});
+
+		it('should allow getting metrics', async () => {
+			const metric = getMetric();
+			register.registerMetric(metric);
+			const metrics = await register.metrics();
+
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect(metrics.split('\n')[3]).toEqual(
+					'test_metric_total{label="bye",code="404"} 34',
+				);
+			} else {
+				expect(metrics.split('\n')[3]).toEqual(
+					'test_metric{label="bye",code="404"} 34',
+				);
+			}
+		});
+
+		describe('resetting', () => {
+			it('should allow resetting all metrics', async () => {
+				const counter = new Counter({
+					name: 'test_counter',
+					help: 'test metric',
+					labelNames: ['serial', 'active'],
+				});
+				const gauge = new Gauge({
+					name: 'test_gauge',
+					help: 'Another test metric',
+					labelNames: ['level'],
+				});
+				const histo = new Histogram({
+					name: 'test_histo',
+					help: 'test',
+				});
+				const summ = new Summary({
+					name: 'test_summ',
+					help: 'test',
+					percentiles: [0.5],
+				});
+				register.registerMetric(counter);
+				register.registerMetric(gauge);
+				register.registerMetric(histo);
+				register.registerMetric(summ);
+
+				counter.inc({ serial: '12345', active: 'yes' }, 12);
+				gauge.set({ level: 'low' }, -12);
+				histo.observe(1);
+				summ.observe(100);
+
+				register.resetMetrics();
+
+				const same_counter = register.getSingleMetric('test_counter');
+				expect((await same_counter.get()).values).toEqual([]);
+
+				const same_gauge = register.getSingleMetric('test_gauge');
+				expect((await same_gauge.get()).values).toEqual([]);
+
+				const same_histo = register.getSingleMetric('test_histo');
+				expect((await same_histo.get()).values).toEqual([]);
+
+				const same_summ = register.getSingleMetric('test_summ');
+				expect((await same_summ.get()).values[0].value).toEqual(0);
+			});
+		});
+
+		describe('Registry with default labels', () => {
+			const Registry = require('../lib/registry');
+
+			describe('mutation tests', () => {
+				describe('registry.metrics()', () => {
+					it('should not throw with default labels (counter)', async () => {
+						const r = new Registry(regType);
+						r.setDefaultLabels({
+							env: 'development',
+						});
+
+						const counter = new Counter({
+							name: 'my_counter',
+							help: 'my counter',
+							registers: [r],
+							labelNames: ['type'],
+						});
+
+						const myCounter = counter.labels('myType');
+
+						myCounter.inc();
+
+						const metrics = await r.metrics();
+						const lines = metrics.split('\n');
+						if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+							expect(lines).toContain(
+								'my_counter_total{type="myType",env="development"} 1',
+							);
+						} else {
+							expect(lines).toContain(
+								'my_counter{type="myType",env="development"} 1',
+							);
+						}
+
+						myCounter.inc();
+
+						const metrics2 = await r.metrics();
+						const lines2 = metrics2.split('\n');
+						if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+							expect(lines2).toContain(
+								'my_counter_total{type="myType",env="development"} 2',
+							);
+						} else {
+							expect(lines2).toContain(
+								'my_counter{type="myType",env="development"} 2',
+							);
+						}
+					});
+
+					it('should not throw with default labels (gauge)', async () => {
+						const r = new Registry(regType);
+						r.setDefaultLabels({
+							env: 'development',
+						});
+
+						const gauge = new Gauge({
+							name: 'my_gauge',
+							help: 'my gauge',
+							registers: [r],
+							labelNames: ['type'],
+						});
+
+						const myGauge = gauge.labels('myType');
+
+						myGauge.inc(1);
+
+						const metrics = await r.metrics();
+						const lines = metrics.split('\n');
+						expect(lines).toContain(
+							'my_gauge{type="myType",env="development"} 1',
+						);
+
+						myGauge.inc(2);
+
+						const metrics2 = await r.metrics();
+						const lines2 = metrics2.split('\n');
+						expect(lines2).toContain(
+							'my_gauge{type="myType",env="development"} 3',
+						);
+					});
+
+					it('should not throw with default labels (histogram)', async () => {
+						const r = new Registry(regType);
+						r.setDefaultLabels({
+							env: 'development',
+						});
+
+						const hist = new Histogram({
+							name: 'my_histogram',
+							help: 'my histogram',
+							registers: [r],
+							labelNames: ['type'],
+						});
+
+						const myHist = hist.labels('myType');
+
+						myHist.observe(1);
+
+						const metrics = await r.metrics();
+						const lines = metrics.split('\n');
+						expect(lines).toContain(
+							'my_histogram_bucket{le="1",type="myType",env="development"} 1',
+						);
+
+						myHist.observe(1);
+
+						const metrics2 = await r.metrics();
+						const lines2 = metrics2.split('\n');
+						expect(lines2).toContain(
+							'my_histogram_bucket{le="1",type="myType",env="development"} 2',
+						);
+					});
+				});
+
+				describe('registry.getMetricsAsJSON()', () => {
+					it('should not throw with default labels (counter)', async () => {
+						const r = new Registry(regType);
+						r.setDefaultLabels({
+							env: 'development',
+						});
+
+						const counter = new Counter({
+							name: 'my_counter',
+							help: 'my counter',
+							registers: [r],
+							labelNames: ['type'],
+						});
+
+						const myCounter = counter.labels('myType');
+
+						myCounter.inc();
+
+						const metrics = await r.getMetricsAsJSON();
+						expect(metrics).toContainEqual({
+							aggregator: 'sum',
+							help: 'my counter',
+							name: 'my_counter',
+							type: 'counter',
+							values: [
+								{
+									labels: { env: 'development', type: 'myType' },
+									value: 1,
+								},
+							],
+						});
+
+						myCounter.inc();
+
+						const metrics2 = await r.getMetricsAsJSON();
+						expect(metrics2).toContainEqual({
+							aggregator: 'sum',
+							help: 'my counter',
+							name: 'my_counter',
+							type: 'counter',
+							values: [
+								{
+									labels: { env: 'development', type: 'myType' },
+									value: 2,
+								},
+							],
+						});
+					});
+
+					it('should not throw with default labels (gauge)', async () => {
+						const r = new Registry(regType);
+						r.setDefaultLabels({
+							env: 'development',
+						});
+
+						const gauge = new Gauge({
+							name: 'my_gauge',
+							help: 'my gauge',
+							registers: [r],
+							labelNames: ['type'],
+						});
+
+						const myGauge = gauge.labels('myType');
+
+						myGauge.inc(1);
+
+						const metrics = await r.getMetricsAsJSON();
+						expect(metrics).toContainEqual({
+							aggregator: 'sum',
+							help: 'my gauge',
+							name: 'my_gauge',
+							type: 'gauge',
+							values: [
+								{
+									labels: { env: 'development', type: 'myType' },
+									value: 1,
+								},
+							],
+						});
+
+						myGauge.inc(2);
+
+						const metrics2 = await r.getMetricsAsJSON();
+						expect(metrics2).toContainEqual({
+							aggregator: 'sum',
+							help: 'my gauge',
+							name: 'my_gauge',
+							type: 'gauge',
+							values: [
+								{
+									labels: { env: 'development', type: 'myType' },
+									value: 3,
+								},
+							],
+						});
+					});
+
+					it('should not throw with default labels (histogram)', async () => {
+						const r = new Registry(regType);
+						r.setDefaultLabels({
+							env: 'development',
+						});
+
+						const hist = new Histogram({
+							name: 'my_histogram',
+							help: 'my histogram',
+							registers: [r],
+							labelNames: ['type'],
+						});
+
+						const myHist = hist.labels('myType');
+
+						myHist.observe(1);
+
+						const metrics = await r.getMetricsAsJSON();
+						// NOTE: at this test we don't need to check exact JSON schema
+						expect(metrics[0].values).toContainEqual({
+							exemplar: null,
+							labels: { env: 'development', le: 1, type: 'myType' },
+							metricName: 'my_histogram_bucket',
+							value: 1,
+						});
+
+						myHist.observe(1);
+
+						const metrics2 = await r.getMetricsAsJSON();
+						// NOTE: at this test we don't need to check exact JSON schema
+						expect(metrics2[0].values).toContainEqual({
+							exemplar: null,
+							labels: { env: 'development', le: 1, type: 'myType' },
+							metricName: 'my_histogram_bucket',
+							value: 2,
+						});
+					});
+				});
+			});
+		});
+
+		describe('merging', () => {
+			const Registry = require('../lib/registry');
+			let registryOne;
+			let registryTwo;
+
+			beforeEach(() => {
+				registryOne = new Registry(regType);
+				registryTwo = new Registry(regType);
+			});
+
+			it('should merge all provided registers', async () => {
+				registryOne.registerMetric(getMetric('one'));
+				registryTwo.registerMetric(getMetric('two'));
+
+				const merged = await Registry.merge([
+					registryOne,
+					registryTwo,
+				]).getMetricsAsJSON();
+				expect(merged).toHaveLength(2);
+			});
+
+			it('should throw if same name exists on both registers', () => {
+				registryOne.registerMetric(getMetric());
+				registryTwo.registerMetric(getMetric());
+
+				const fn = function () {
+					Registry.merge([registryOne, registryTwo]);
 				};
-			},
-		});
-		const escapedResult = await register.metrics();
-		expect(escapedResult).toMatch(/\\"/);
-	});
 
-	describe('should output metrics as JSON', () => {
-		it('should output metrics as JSON', async () => {
-			register.registerMetric(getMetric());
-			const output = await register.getMetricsAsJSON();
-
-			expect(output.length).toEqual(1);
-			expect(output[0].name).toEqual('test_metric');
-			expect(output[0].type).toEqual('counter');
-			expect(output[0].help).toEqual('A test metric');
-			expect(output[0].values.length).toEqual(2);
-		});
-
-		it('should add default labels to JSON', async () => {
-			register.registerMetric(getMetric());
-			register.setDefaultLabels({
-				defaultRegistryLabel: 'testValue',
+				expect(fn).toThrowError(Error);
 			});
-			const output = await register.getMetricsAsJSON();
 
-			expect(output.length).toEqual(1);
-			expect(output[0].name).toEqual('test_metric');
-			expect(output[0].type).toEqual('counter');
-			expect(output[0].help).toEqual('A test metric');
-			expect(output[0].values.length).toEqual(2);
-			expect(output[0].values[0].labels).toEqual({
-				code: '303',
-				label: 'hello',
-				defaultRegistryLabel: 'testValue',
+			it('should throw if merging different types of registers', () => {
+				registryOne.setContentType(Registry.PROMETHEUS_CONTENT_TYPE);
+				registryTwo.setContentType(Registry.OPENMETRICS_CONTENT_TYPE);
+
+				const fn = function () {
+					Registry.merge([registryOne, registryTwo]);
+				};
+
+				expect(fn).toThrowError(
+					'Registers can only be merged if they have the same content type',
+				);
 			});
 		});
-	});
 
-	it('should allow removing single metrics', async () => {
-		register.registerMetric(getMetric());
-		register.registerMetric(getMetric('some other name'));
-
-		let output = await register.getMetricsAsJSON();
-		expect(output.length).toEqual(2);
-
-		register.removeSingleMetric('test_metric');
-
-		output = await register.getMetricsAsJSON();
-
-		expect(output.length).toEqual(1);
-		expect(output[0].name).toEqual('some other name');
-	});
-
-	it('should allow getting single metrics', () => {
-		const metric = getMetric();
-		register.registerMetric(metric);
-
-		const output = register.getSingleMetric('test_metric');
-		expect(output).toEqual(metric);
-	});
-
-	it('should allow getting metrics', async () => {
-		const metric = getMetric();
-		register.registerMetric(metric);
-		const metrics = await register.metrics();
-
-		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-			expect(metrics.split('\n')[3]).toEqual(
-				'test_metric_total{label="bye",code="404"} 34',
-			);
-		} else {
-			expect(metrics.split('\n')[3]).toEqual(
-				'test_metric{label="bye",code="404"} 34',
-			);
+		function getMetric(name) {
+			name = name || 'test_metric';
+			return {
+				name,
+				async get() {
+					return {
+						name,
+						type: 'counter',
+						help: 'A test metric',
+						values: [
+							{
+								value: 12,
+								labels: {
+									label: 'hello',
+									code: '303',
+								},
+							},
+							{
+								value: 34,
+								labels: {
+									label: 'bye',
+									code: '404',
+								},
+							},
+						],
+					};
+				},
+			};
 		}
 	});
-
-	describe('resetting', () => {
-		it('should allow resetting all metrics', async () => {
-			const counter = new Counter({
-				name: 'test_counter',
-				help: 'test metric',
-				labelNames: ['serial', 'active'],
-			});
-			const gauge = new Gauge({
-				name: 'test_gauge',
-				help: 'Another test metric',
-				labelNames: ['level'],
-			});
-			const histo = new Histogram({
-				name: 'test_histo',
-				help: 'test',
-			});
-			const summ = new Summary({
-				name: 'test_summ',
-				help: 'test',
-				percentiles: [0.5],
-			});
-			register.registerMetric(counter);
-			register.registerMetric(gauge);
-			register.registerMetric(histo);
-			register.registerMetric(summ);
-
-			counter.inc({ serial: '12345', active: 'yes' }, 12);
-			gauge.set({ level: 'low' }, -12);
-			histo.observe(1);
-			summ.observe(100);
-
-			register.resetMetrics();
-
-			const same_counter = register.getSingleMetric('test_counter');
-			expect((await same_counter.get()).values).toEqual([]);
-
-			const same_gauge = register.getSingleMetric('test_gauge');
-			expect((await same_gauge.get()).values).toEqual([]);
-
-			const same_histo = register.getSingleMetric('test_histo');
-			expect((await same_histo.get()).values).toEqual([]);
-
-			const same_summ = register.getSingleMetric('test_summ');
-			expect((await same_summ.get()).values[0].value).toEqual(0);
-		});
-	});
-
-	describe('Registry with default labels', () => {
-		const Registry = require('../lib/registry');
-
-		describe('mutation tests', () => {
-			describe('registry.metrics()', () => {
-				it('should not throw with default labels (counter)', async () => {
-					const r = new Registry(regType);
-					r.setDefaultLabels({
-						env: 'development',
-					});
-
-					const counter = new Counter({
-						name: 'my_counter',
-						help: 'my counter',
-						registers: [r],
-						labelNames: ['type'],
-					});
-
-					const myCounter = counter.labels('myType');
-
-					myCounter.inc();
-
-					const metrics = await r.metrics();
-					const lines = metrics.split('\n');
-					if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-						expect(lines).toContain(
-							'my_counter_total{type="myType",env="development"} 1',
-						);
-					} else {
-						expect(lines).toContain(
-							'my_counter{type="myType",env="development"} 1',
-						);
-					}
-
-					myCounter.inc();
-
-					const metrics2 = await r.metrics();
-					const lines2 = metrics2.split('\n');
-					if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
-						expect(lines2).toContain(
-							'my_counter_total{type="myType",env="development"} 2',
-						);
-					} else {
-						expect(lines2).toContain(
-							'my_counter{type="myType",env="development"} 2',
-						);
-					}
-				});
-
-				it('should not throw with default labels (gauge)', async () => {
-					const r = new Registry(regType);
-					r.setDefaultLabels({
-						env: 'development',
-					});
-
-					const gauge = new Gauge({
-						name: 'my_gauge',
-						help: 'my gauge',
-						registers: [r],
-						labelNames: ['type'],
-					});
-
-					const myGauge = gauge.labels('myType');
-
-					myGauge.inc(1);
-
-					const metrics = await r.metrics();
-					const lines = metrics.split('\n');
-					expect(lines).toContain(
-						'my_gauge{type="myType",env="development"} 1',
-					);
-
-					myGauge.inc(2);
-
-					const metrics2 = await r.metrics();
-					const lines2 = metrics2.split('\n');
-					expect(lines2).toContain(
-						'my_gauge{type="myType",env="development"} 3',
-					);
-				});
-
-				it('should not throw with default labels (histogram)', async () => {
-					const r = new Registry(regType);
-					r.setDefaultLabels({
-						env: 'development',
-					});
-
-					const hist = new Histogram({
-						name: 'my_histogram',
-						help: 'my histogram',
-						registers: [r],
-						labelNames: ['type'],
-					});
-
-					const myHist = hist.labels('myType');
-
-					myHist.observe(1);
-
-					const metrics = await r.metrics();
-					const lines = metrics.split('\n');
-					expect(lines).toContain(
-						'my_histogram_bucket{le="1",type="myType",env="development"} 1',
-					);
-
-					myHist.observe(1);
-
-					const metrics2 = await r.metrics();
-					const lines2 = metrics2.split('\n');
-					expect(lines2).toContain(
-						'my_histogram_bucket{le="1",type="myType",env="development"} 2',
-					);
-				});
-			});
-
-			describe('registry.getMetricsAsJSON()', () => {
-				it('should not throw with default labels (counter)', async () => {
-					const r = new Registry(regType);
-					r.setDefaultLabels({
-						env: 'development',
-					});
-
-					const counter = new Counter({
-						name: 'my_counter',
-						help: 'my counter',
-						registers: [r],
-						labelNames: ['type'],
-					});
-
-					const myCounter = counter.labels('myType');
-
-					myCounter.inc();
-
-					const metrics = await r.getMetricsAsJSON();
-					expect(metrics).toContainEqual({
-						aggregator: 'sum',
-						help: 'my counter',
-						name: 'my_counter',
-						type: 'counter',
-						values: [
-							{
-								labels: { env: 'development', type: 'myType' },
-								value: 1,
-							},
-						],
-					});
-
-					myCounter.inc();
-
-					const metrics2 = await r.getMetricsAsJSON();
-					expect(metrics2).toContainEqual({
-						aggregator: 'sum',
-						help: 'my counter',
-						name: 'my_counter',
-						type: 'counter',
-						values: [
-							{
-								labels: { env: 'development', type: 'myType' },
-								value: 2,
-							},
-						],
-					});
-				});
-
-				it('should not throw with default labels (gauge)', async () => {
-					const r = new Registry(regType);
-					r.setDefaultLabels({
-						env: 'development',
-					});
-
-					const gauge = new Gauge({
-						name: 'my_gauge',
-						help: 'my gauge',
-						registers: [r],
-						labelNames: ['type'],
-					});
-
-					const myGauge = gauge.labels('myType');
-
-					myGauge.inc(1);
-
-					const metrics = await r.getMetricsAsJSON();
-					expect(metrics).toContainEqual({
-						aggregator: 'sum',
-						help: 'my gauge',
-						name: 'my_gauge',
-						type: 'gauge',
-						values: [
-							{
-								labels: { env: 'development', type: 'myType' },
-								value: 1,
-							},
-						],
-					});
-
-					myGauge.inc(2);
-
-					const metrics2 = await r.getMetricsAsJSON();
-					expect(metrics2).toContainEqual({
-						aggregator: 'sum',
-						help: 'my gauge',
-						name: 'my_gauge',
-						type: 'gauge',
-						values: [
-							{
-								labels: { env: 'development', type: 'myType' },
-								value: 3,
-							},
-						],
-					});
-				});
-
-				it('should not throw with default labels (histogram)', async () => {
-					const r = new Registry(regType);
-					r.setDefaultLabels({
-						env: 'development',
-					});
-
-					const hist = new Histogram({
-						name: 'my_histogram',
-						help: 'my histogram',
-						registers: [r],
-						labelNames: ['type'],
-					});
-
-					const myHist = hist.labels('myType');
-
-					myHist.observe(1);
-
-					const metrics = await r.getMetricsAsJSON();
-					// NOTE: at this test we don't need to check exact JSON schema
-					expect(metrics[0].values).toContainEqual({
-						exemplar: null,
-						labels: { env: 'development', le: 1, type: 'myType' },
-						metricName: 'my_histogram_bucket',
-						value: 1,
-					});
-
-					myHist.observe(1);
-
-					const metrics2 = await r.getMetricsAsJSON();
-					// NOTE: at this test we don't need to check exact JSON schema
-					expect(metrics2[0].values).toContainEqual({
-						exemplar: null,
-						labels: { env: 'development', le: 1, type: 'myType' },
-						metricName: 'my_histogram_bucket',
-						value: 2,
-					});
-				});
-			});
-		});
-	});
-
-	describe('merging', () => {
-		const Registry = require('../lib/registry');
-		let registryOne;
-		let registryTwo;
-
-		beforeEach(() => {
-			registryOne = new Registry(regType);
-			registryTwo = new Registry(regType);
-		});
-
-		it('should merge all provided registers', async () => {
-			registryOne.registerMetric(getMetric('one'));
-			registryTwo.registerMetric(getMetric('two'));
-
-			const merged = await Registry.merge([
-				registryOne,
-				registryTwo,
-			]).getMetricsAsJSON();
-			expect(merged).toHaveLength(2);
-		});
-
-		it('should throw if same name exists on both registers', () => {
-			registryOne.registerMetric(getMetric());
-			registryTwo.registerMetric(getMetric());
-
-			const fn = function () {
-				Registry.merge([registryOne, registryTwo]);
-			};
-
-			expect(fn).toThrowError(Error);
-		});
-	});
-
-	function getMetric(name) {
-		name = name || 'test_metric';
-		return {
-			name,
-			async get() {
-				return {
-					name,
-					type: 'counter',
-					help: 'A test metric',
-					values: [
-						{
-							value: 12,
-							labels: {
-								label: 'hello',
-								code: '303',
-							},
-						},
-						{
-							value: 34,
-							labels: {
-								label: 'bye',
-								code: '404',
-							},
-						},
-					],
-				};
-			},
-		};
-	}
 });

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -3,9 +3,9 @@
 const Registry = require('../index').Registry;
 
 describe.each([
-	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
-	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
-])('summary with $tag registry', ({ tag, regType }) => {
+	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
+	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
+])('summary with %s registry', (tag, regType) => {
 	const Summary = require('../index').Summary;
 	const globalRegistry = require('../index').register;
 	let instance;

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -1,10 +1,22 @@
 'use strict';
 
-describe('summary', () => {
+const Registry = require('../index').Registry;
+
+describe.each([
+	{ tag: 'Prometheus', regType: Registry.PROMETHEUS_CONTENT_TYPE },
+	{ tag: 'OpenMetrics', regType: Registry.OPENMETRICS_CONTENT_TYPE },
+])('summary with $tag registry', ({ tag, regType }) => {
 	const Summary = require('../index').Summary;
-	const Registry = require('../index').Registry;
 	const globalRegistry = require('../index').register;
 	let instance;
+
+	beforeEach(() => {
+		globalRegistry.setContentType(regType);
+	});
+
+	afterEach(() => {
+		globalRegistry.clear();
+	});
 
 	describe('global registry', () => {
 		afterEach(() => {
@@ -464,7 +476,7 @@ describe('summary', () => {
 	describe('registry instance', () => {
 		let registryInstance;
 		beforeEach(() => {
-			registryInstance = new Registry();
+			registryInstance = new Registry(regType);
 			instance = new Summary({
 				name: 'summary_test',
 				help: 'test',


### PR DESCRIPTION
### Overview

- Added support for the OpenTelemetry standard
- Added support for automatically providing exemplars populated by with trace information from OpenTelemetry

The main purpose of the PR is to enable the use of Exemplars for NodeJS codebase.

Relevant resources:

[Grafana exemplars](https://grafana.com/docs/grafana/latest/basics/exemplars/)
[Prometheus exemplars](https://prometheus.io/docs/prometheus/latest/feature_flags/#exemplars-storage)
[OpenMetics spec](https://github.com/OpenObservability/OpenMetrics/blob/d99b705f611b75fec8f450b05e344e02eea6921d/specification/OpenMetrics.md)
[Prometheus format](https://prometheus.io/docs/instrumenting/exposition_formats/)

### Design

The OpenTelemetry standard is very close to the original Prometheus format. In order to keep the library as backwards compatible as possible the default format is kept unchanged (Prometheus) and the use of exemplars is disabled.

The new features can be toggled:

- The format at the registry level (prometheus/openmetrics)
- The exemplars at the metric level

Each registry instance has an attribute (contentType) that will decide the format.
The two possible formats are defined by the constants `OPENMETRICS_CONTENT_TYPE` and `PROMETHEUS_CONTENT_TYPE` which contain the HTTP content type.
Future versions [should default](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#protocol-negotiation) to the `1.0.0` version.

Each metric has a flag for enabling the exemplar, the flag is put on the metrics supeclass for simplicity, but out of the currently implemented metric types only histograms and counters can have [exemplars](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-types-1).

The biggest change to the code is the creation of separate functions for Counter increment and Histogram observe. Because the functions need to support a third optional parameter (exemplar labels) I have changed the way parameters are passed to the functions. Instead of using plain `(label, value)` the users will need to provide a single object with the format `({labels, value, exemplarLabels})`, with `labels` and `exemplarLabels` being optional.
The change should not impact existing users, but users who want to use exemplars will need to use the new call format.

**Exemplar object**

Timestamp - is the time when the exemplar was created
Reference from the Golang client: [https://github.com/prometheus/client_golang/blob/1b145cad6847a692bd07e872d64b7102d33213c6/prometheus/histogram.go#L432](https://github.com/prometheus/client_golang/blob/1b145cad6847a692bd07e872d64b7102d33213c6/prometheus/histogram.go#L432).

[There is a hard 128 UTF-8 character limit on exemplar length.](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#size-limits)